### PR TITLE
Image field to article

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,8 @@ libraryDependencies += "junit" % "junit" % "4.10" % "test"
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 
 /*deps for simple client*/
-libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.4.3"
+//libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.4.3"
+libraryDependencies +=  "org.scalaj" %% "scalaj-http" % "2.3.0"
 
 /* deps for Riff-Raff Guardian deployment tool */
 enablePlugins(RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,9 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 libraryDependencies += "junit" % "junit" % "4.10" % "test"
 libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
 
+/*deps for simple client*/
+libraryDependencies += "com.typesafe.play" %% "play-ws" % "2.4.3"
+
 /* deps for Riff-Raff Guardian deployment tool */
 enablePlugins(RiffRaffArtifact)
 

--- a/src/main/scala/com/gu/kindlegen/Article.scala
+++ b/src/main/scala/com/gu/kindlegen/Article.scala
@@ -32,10 +32,10 @@ object Article {
     val elements = content.elements
     val mainImage = elements.flatMap(_.find(isMainImage))
     val imageAsset = mainImage.flatMap(_.assets.find(isCorrectSizedAsset))
+    // keep imageUrl as an option otherwise later you will try to download form an empty string
     val imageUrl = imageAsset.flatMap(_.typeData).flatMap(_.secureFile)
     imageUrl
   }
-  // keep this as an option otherwise later you will try to download form an empty string
   // TODO: get rid of the gets
   def apply(contentWithIndex: (Content, Int)): Article = {
     val content = contentWithIndex._1

--- a/src/main/scala/com/gu/kindlegen/Article.scala
+++ b/src/main/scala/com/gu/kindlegen/Article.scala
@@ -35,7 +35,7 @@ object Article {
     imageUrl
   }
   // keep this as an option otherwise later you will try to download form an empty string
-
+  // TODO: get rid of the gets
   def apply(content: Content): Article = new Article(
     newspaperBookSection = content.tags.find(_.`type` == NewspaperBookSection).get.id,
     sectionName = content.tags.find(_.`type` == NewspaperBookSection).get.webTitle,

--- a/src/main/scala/com/gu/kindlegen/Article.scala
+++ b/src/main/scala/com/gu/kindlegen/Article.scala
@@ -1,5 +1,8 @@
 package com.gu.kindlegen
 
+import com.gu.contentapi.client.model.v1.Asset
+import com.gu.contentapi.client.model.v1.Element
+import com.gu.contentapi.client.model.v1.ElementType.Image
 import com.gu.contentapi.client.model.v1.TagType.NewspaperBookSection
 import com.gu.contentapi.client.model.v1._
 
@@ -10,26 +13,40 @@ case class Article(
   title: String,
   docId: String,
   issueDate: CapiDateTime,
-  // newspaperEditionDate in ContentFields
   releaseDate: CapiDateTime,
   pubDate: CapiDateTime,
   byline: String,
-  articleAbstract: String, // standfirst is used
-  content: String
+  articleAbstract: String,
+  content: String,
+  imageUrl: Option[String]
 )
 
 object Article {
+  def getImageUrl(content: Content): Option[String] = {
+    def isMainImage(e: Element): Boolean =
+      e.`type` == Image && e.relation == "main"
+    def isCorrectSizedAsset(a: Asset): Boolean =
+      a.typeData.flatMap(_.width) == Some(500)
+
+    val elements = content.elements
+    val mainImage = elements.flatMap(_.find(isMainImage))
+    val imageAsset = mainImage.flatMap(_.assets.find(isCorrectSizedAsset))
+    val imageUrl = imageAsset.flatMap(_.typeData).flatMap(_.secureFile)
+    imageUrl
+  }
+  // keep this as an option otherwise later you will try to download form an empty string
+
   def apply(content: Content): Article = new Article(
-    newspaperBookSection = content.tags.find(_.`type` == NewspaperBookSection).get.id, // FIXME: NB this will throw exception if this tag is missing!
-    sectionName = content.tags.find(_.`type` == NewspaperBookSection).get.webTitle, // FIXME: NB this will throw exception if this tag is missing!
+    newspaperBookSection = content.tags.find(_.`type` == NewspaperBookSection).get.id,
+    sectionName = content.tags.find(_.`type` == NewspaperBookSection).get.webTitle,
     newspaperPageNumber = content.fields.flatMap(_.newspaperPageNumber).getOrElse(0),
     title = content.fields.flatMap(_.headline).getOrElse("").toString,
     docId = content.id,
     issueDate = content.fields.flatMap(_.newspaperEditionDate).get,
     releaseDate = content.fields.flatMap(_.newspaperEditionDate).get,
     pubDate = content.fields.flatMap(_.newspaperEditionDate).get,
-    byline = content.fields.flatMap(_.byline).getOrElse(""),
-    articleAbstract = content.fields.flatMap(_.standfirst).getOrElse(""),
-    content = content.fields.flatMap(_.body).getOrElse("")
+    byline = content.fields.flatMap(_.byline).getOrElse(""), articleAbstract = content.fields.flatMap(_.standfirst).getOrElse(""),
+    content = content.fields.flatMap(_.body).getOrElse(""),
+    imageUrl = getImageUrl(content: Content)
   )
 }

--- a/src/main/scala/com/gu/kindlegen/Article.scala
+++ b/src/main/scala/com/gu/kindlegen/Article.scala
@@ -18,7 +18,8 @@ case class Article(
   byline: String,
   articleAbstract: String,
   content: String,
-  imageUrl: Option[String]
+  imageUrl: Option[String],
+  fileId: Int
 )
 
 object Article {
@@ -36,17 +37,22 @@ object Article {
   }
   // keep this as an option otherwise later you will try to download form an empty string
   // TODO: get rid of the gets
-  def apply(content: Content): Article = new Article(
-    newspaperBookSection = content.tags.find(_.`type` == NewspaperBookSection).get.id,
-    sectionName = content.tags.find(_.`type` == NewspaperBookSection).get.webTitle,
-    newspaperPageNumber = content.fields.flatMap(_.newspaperPageNumber).getOrElse(0),
-    title = content.fields.flatMap(_.headline).getOrElse("").toString,
-    docId = content.id,
-    issueDate = content.fields.flatMap(_.newspaperEditionDate).get,
-    releaseDate = content.fields.flatMap(_.newspaperEditionDate).get,
-    pubDate = content.fields.flatMap(_.newspaperEditionDate).get,
-    byline = content.fields.flatMap(_.byline).getOrElse(""), articleAbstract = content.fields.flatMap(_.standfirst).getOrElse(""),
-    content = content.fields.flatMap(_.body).getOrElse(""),
-    imageUrl = getImageUrl(content: Content)
-  )
+  def apply(contentWithIndex: (Content, Int)): Article = {
+    val content = contentWithIndex._1
+    val index = contentWithIndex._2
+    Article(
+      newspaperBookSection = content.tags.find(_.`type` == NewspaperBookSection).get.id,
+      sectionName = content.tags.find(_.`type` == NewspaperBookSection).get.webTitle,
+      newspaperPageNumber = content.fields.flatMap(_.newspaperPageNumber).getOrElse(0),
+      title = content.fields.flatMap(_.headline).getOrElse("").toString,
+      docId = content.id,
+      issueDate = content.fields.flatMap(_.newspaperEditionDate).get,
+      releaseDate = content.fields.flatMap(_.newspaperEditionDate).get,
+      pubDate = content.fields.flatMap(_.newspaperEditionDate).get,
+      byline = content.fields.flatMap(_.byline).getOrElse(""), articleAbstract = content.fields.flatMap(_.standfirst).getOrElse(""),
+      content = content.fields.flatMap(_.body).getOrElse(""),
+      imageUrl = getImageUrl(content: Content),
+      fileId = index
+    )
+  }
 }

--- a/src/main/scala/com/gu/kindlegen/BookSectionPage.scala
+++ b/src/main/scala/com/gu/kindlegen/BookSectionPage.scala
@@ -5,9 +5,6 @@ package com.gu.kindlegen
  */
 case class BookSectionPage(bookSectionId: String, pageNum: Int, articles: List[Article])
 
-// TODO: Ask David B if I should group by BookSectionPage as well as page number - as in, can a page have two book sections in?
-// If a page can have two sections, the ordering could be problematic - chunkBy assumes that the sections will be in order...
-// TODO: allow edge case where a page can have more than one book section on it.
 // TODO: Ask DB if the order INSIDE the pages matters (ie order of the articles) and if so how I recreate this.
 
 object BookSectionPage {

--- a/src/main/scala/com/gu/kindlegen/BookSectionPage.scala
+++ b/src/main/scala/com/gu/kindlegen/BookSectionPage.scala
@@ -6,13 +6,17 @@ package com.gu.kindlegen
 case class BookSectionPage(bookSectionId: String, pageNum: Int, articles: List[Article])
 
 // TODO: Ask David B if I should group by BookSectionPage as well as page number - as in, can a page have two book sections in?
+// If a page can have two sections, the ordering could be problematic - chunkBy assumes that the sections will be in order...
 // TODO: allow edge case where a page can have more than one book section on it.
 // TODO: Ask DB if the order INSIDE the pages matters (ie order of the articles) and if so how I recreate this.
 
 object BookSectionPage {
 
   def chunkByPageNum(articles: List[Article]): List[List[Article]] = {
-    ListUtil.chunkBy(articles, getNewspaperPageNumber)
+    // TODO: sort articles in/before responseToArticles method
+    val sortedArticles = articles.sortBy(_.newspaperPageNumber)
+
+    ListUtil.chunkBy(sortedArticles, getNewspaperPageNumber)
   }
 
   private def getNewspaperPageNumber(article: Article): Int = article.newspaperPageNumber

--- a/src/main/scala/com/gu/kindlegen/DateUtils.scala
+++ b/src/main/scala/com/gu/kindlegen/DateUtils.scala
@@ -21,6 +21,7 @@ object DateUtils {
 
   // TODO: change this to DateTime.now or function that takes a passed in date.
   def editionDateTime: DateTime = formatterWithDashes.parseDateTime("2017-05-19") // to have a date I know the results for
+  //  def editionDateTime: DateTime = DateTime.now()
 
   def editionDateString: String = formatterWithDashes.print(editionDateTime)
   def editionDateStart: DateTime = DateTime.parse(editionDateString).withMillisOfDay(0).withMillisOfSecond(0)

--- a/src/main/scala/com/gu/kindlegen/Querier.scala
+++ b/src/main/scala/com/gu/kindlegen/Querier.scala
@@ -32,16 +32,6 @@ object Querier {
 
   def getPrintSentResponse: Seq[com.gu.contentapi.client.model.v1.Content] = {
 
-    //    def editionDateTime: DateTime = DateTime.now
-    def editionDateTime: DateTime = formatter.parseDateTime("2017-05-19") // to have a date I know the results for
-    def editionDateString: String = formatter.print(editionDateTime)
-
-    def editionDateStart: DateTime = DateTime.parse(editionDateString).withMillisOfDay(0).withMillisOfSecond(0)
-
-    def editionDateEnd: DateTime = DateTime.parse(editionDateString).withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59).withMillisOfSecond(999)
-
-    //    def editionDateTime: DateTime = DateTime.now
-
     val capiKey = readApiKey
     val capiClient = new PrintSentContentClient(capiKey)
     val pageNum = 1
@@ -56,13 +46,19 @@ object Querier {
       .showFields("newspaper-page-number, headline,newspaper-edition-date,byline,standfirst,body")
       // TODO: what fields are required? main? content? Is tag `newspaper-book` required
       .showTags("newspaper-book-section, newspaper-book")
-    //.showElements("image")
+      .showElements("image")
     // TODO: Add error handling with Try for failed request.
     // TODO: Currently gets one result only; separate out sections and map over multiple pageSizes/ pages
     // TODO: Query requires use-date and exact date of publication
     val response = Await.result(capiClient.getResponse(query), 5.seconds)
     response.results
   }
+  // TODO: with show-elements=image in the request get an elemnet sublist of images including a sublist of assets which have type = image and a typedata sublist including width - only want the width 500 image
+  // The Kindle NITF spec is for max image size https://images-na.ssl-images-amazon.com/images/G/01/kindle-publication/feedGuide-new/KPPUserGuide._V181169266_.html#AddingImages
+  // max size is 960 x 720 corresps with our 500 width best
+  // in the typedata there is a link called secureFile and this is where I want to retrieve the image from (or maybe just the topsection `file`
+  // as well as the fingerpost file, kindleprevier also gets these files in an async way - how?
+  // best plan is probably to add all the functionality in terms of section and class and do the async download later
 
   def responseToArticles(response: Seq[com.gu.contentapi.client.model.v1.Content]): Seq[Article] = {
     response.map(responseContent =>

--- a/src/main/scala/com/gu/kindlegen/Querier.scala
+++ b/src/main/scala/com/gu/kindlegen/Querier.scala
@@ -72,14 +72,15 @@ object Querier {
   */
 
   def responseToArticles(response: Seq[Content]): Seq[Article] = {
-    response.map(responseContent =>
-      Article(responseContent))
+    val sortedContent = Querier.sortContentByPageAndSection(response)
+    val contentWithIndex = sortedContent.view.zipWithIndex.toList
+    contentWithIndex.map(Article.apply)
   }
   // Probably best to merge these functions OR
   // put the article index/id into the article class so you dont have to pass around a tuple.
-  def articlesWithFileIdentifier(articles: Seq[Article]): List[(Article, Int)] = {
-    articles.view.zipWithIndex.toList
-  }
+  //  def articlesWithFileIdentifier(articles: Seq[Article]): List[(Article, Int)] = {
+  //    articles.view.zipWithIndex.toList
+  //  }
 
   def sortContentByPageAndSection(response: Seq[Content]): Seq[Content] = {
     response.sortBy(content => (content.fields.flatMap(_.newspaperPageNumber), content.tags.find(_.`type` == NewspaperBookSection).get.id))

--- a/src/main/scala/com/gu/kindlegen/Querier.scala
+++ b/src/main/scala/com/gu/kindlegen/Querier.scala
@@ -1,7 +1,4 @@
 package com.gu.kindlegen
-import java.awt.image.BufferedImage
-import java.io._
-import javax.imageio.ImageIO
 
 import com.gu.contentapi.client._
 import com.gu.contentapi.client.model._
@@ -49,12 +46,12 @@ object Querier {
       .useDate("newspaper-edition")
       //      .page(pageNum)
       .showFields("newspaper-page-number, headline,newspaper-edition-date,byline,standfirst,body")
-      // TODO: what fields are required? main? content? Is tag `newspaper-book` required
       .showTags("newspaper-book-section, newspaper-book")
       .showElements("image")
     // TODO: Add error handling with Try for failed request.
     // TODO: Currently gets one result only; separate out sections and map over multiple pageSizes/ pages
     // TODO: Query requires use-date and exact date of publication
+    // TODO: Add pagination
     val response = Await.result(capiClient.getResponse(query), 5.seconds)
     response.results
   }
@@ -91,3 +88,5 @@ object Querier {
       case e: Exception => None
     }
 }
+
+// TODO: create a fileStructure model class with paths and file names.

--- a/src/main/scala/com/gu/kindlegen/Querier.scala
+++ b/src/main/scala/com/gu/kindlegen/Querier.scala
@@ -9,6 +9,8 @@ import scala.concurrent.duration._
 import scala.io.{ BufferedSource, Source }
 import org.joda.time.DateTime
 import DateUtils._
+import play.api.libs.ws.ning.NingWSClient
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class Querier {
 }
@@ -65,5 +67,56 @@ object Querier {
       Article(responseContent))
   }
 
-}
+  /*  def getArticleImage(article: Article) = {
+    val wsClient = NingWSClient()
+    if (article.imageUrl.isEmpty) {
+      sys.error("no suitable image found for this article")
+    }
+    wsClient
+      .url(article.imageUrl.get)
+      .get()
+      .map { wsResponse =>
+        if (!(200 to 299).contains(wsResponse.status)) {
+          sys.error(s"Received unexpected status ${wsResponse.status} : ${wsResponse.body}")
+        }
+        println(s"OK, received ${wsResponse.body}")
+        println(s"The response header Content-Length was ${wsResponse.header("Content-Length")}")
+      }
+    wsClient.close
+  }*/
+  //  @throws(classOf[java.io.IOException])
+  //  @throws(classOf[java.net.SocketTimeoutException])
+  //  def get(
+  //    url: String,
+  //    connectTimeout: Int = 5000,
+  //    readTimeout: Int = 5000,
+  //    requestMethod: String = "GET"
+  //  ) =
+  //    {
+  //      import java.net.{ URL, HttpURLConnection }
+  //      val connection = (new URL(url)).openConnection.asInstanceOf[HttpURLConnection]
+  //      connection.setConnectTimeout(connectTimeout)
+  //      connection.setReadTimeout(readTimeout)
+  //      connection.setRequestMethod(requestMethod)
+  //      val inputStream = connection.getInputStream
+  //      val content = io.Source.fromInputStream(inputStream).mkString
+  //      if (inputStream != null) inputStream.close
+  //      content
+  //    }
+  //
+  //  def getArticleImage(article: Article) = {
+  //    try {
+  //      val content = get(article.imageUrl.get)
+  //      println(content)
+  //    } catch {
+  //      case ioe: java.io.IOException => println("ohno IO exception") // TODO: handle
+  //      case ste: java.net.SocketTimeoutException => println("ohno socket timeout") // TODO: handle this
+  //    }
+  //  }
 
+  def getArticleImage(article: Article) = {
+    import javax.imageio.ImageIO
+    import java.net.URL
+    ImageIO.read(new URL(article.imageUrl.get))
+  }
+}

--- a/src/main/scala/com/gu/kindlegen/SectionManifest.scala
+++ b/src/main/scala/com/gu/kindlegen/SectionManifest.scala
@@ -39,16 +39,13 @@ object SectionManifest {
     )
   }
 
-  // TODO: Write test
-  // TODO: Filter duplicates
-  // TODO: Replace / with _
   def toSectionHeading(articles: Seq[Article]): Seq[SectionHeading] = {
     val allHeadings = articles.map(article =>
       SectionHeading(article))
     allHeadings.distinct
   }
 
-  // TODO: Write to files/folders
+  // TODO: Write to files/folders structure
 }
 
 case class SectionHeading(

--- a/src/main/scala/com/gu/kindlegen/SectionManifest.scala
+++ b/src/main/scala/com/gu/kindlegen/SectionManifest.scala
@@ -27,7 +27,7 @@ case class SectionManifest(
        |</rss>
       """.stripMargin
   }
-  // TODO: in the NITF outputs the section manifest content page has a `Z` appended to the date. This is probably a mistake in the fingerpost script but worth checking
+  // TODO: in the NITF outputs the section manifest content page has a `Z` appended to the date. This is probably a mistake in the fingerpost script but worth checking ASK DB
 }
 
 object SectionManifest {

--- a/src/main/scala/com/gu/kindlegen/SectionManifest.scala
+++ b/src/main/scala/com/gu/kindlegen/SectionManifest.scala
@@ -32,7 +32,7 @@ case class SectionManifest(
 
 object SectionManifest {
   def apply(articles: Seq[Article], buildDate: DateTime = DateTime.now): SectionManifest = {
-    new SectionManifest(
+    SectionManifest(
       publicationDate = articles.head.issueDate,
       buildDate = buildDate,
       sections = toSectionHeading(articles)
@@ -66,7 +66,7 @@ case class SectionHeading(
 }
 
 object SectionHeading {
-  def apply(article: Article) = new SectionHeading(
+  def apply(article: Article): SectionHeading = SectionHeading(
     title = article.sectionName,
     titleLink = article.newspaperBookSection
   )

--- a/src/test/scala/com/gu/kindlegen/ArticleNITFSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleNITFSuite.scala
@@ -21,8 +21,10 @@ class ArticleNITFSuite extends FunSuite {
       pubDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime,
       byline = "my name",
       articleAbstract = "article abstract",
-      content = "content"
+      content = "content",
+      imageUrl = None
     )
+
     val expectedOutput =
       """
         |<?xml version="1.0" encoding="UTF-8"?>

--- a/src/test/scala/com/gu/kindlegen/ArticleNITFSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleNITFSuite.scala
@@ -22,7 +22,8 @@ class ArticleNITFSuite extends FunSuite {
       byline = "my name",
       articleAbstract = "article abstract",
       content = "content",
-      imageUrl = None
+      imageUrl = None,
+      fileId = 0
     )
 
     val expectedOutput =

--- a/src/test/scala/com/gu/kindlegen/ArticleSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleSuite.scala
@@ -11,7 +11,7 @@ import DateUtils._
 class ArticleSuite extends FunSuite {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val ta = TestContent("", "", 2, "", "", capiDate, capiDate, capiDate, "", "", "")
+  val ta = TestContent("", "", 2, "", "", capiDate, capiDate, capiDate, "", "", "", None)
 
   test("apply method with content as parameter") {
     val content = ta.toContent

--- a/src/test/scala/com/gu/kindlegen/ArticleSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleSuite.scala
@@ -1,21 +1,18 @@
 package com.gu.kindlegen
 
-import org.scalatest.FunSuite
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.utils._
 import DateUtils._
 
-@RunWith(classOf[JUnitRunner])
-class ArticleSuite extends FunSuite {
+class ArticleSuite extends FlatSpec {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val ta = TestContent("", "", 2, "", "", capiDate, capiDate, capiDate, "", "", "", None)
+  val ta = TestContent("", "", 2, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0)
 
-  test("apply method with content as parameter") {
+  ".apply" should "apply method with content as parameter" in {
     val content = ta.toContent
-    val a = Article(content: Content)
+    val a = Article((content, 0))
     assert(a.newspaperPageNumber === 2)
   }
 }

--- a/src/test/scala/com/gu/kindlegen/ArticleSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleSuite.scala
@@ -1,7 +1,6 @@
 package com.gu.kindlegen
 
 import org.scalatest.FlatSpec
-import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.utils._
 import DateUtils._
 

--- a/src/test/scala/com/gu/kindlegen/BookSectionPageSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/BookSectionPageSuite.scala
@@ -10,7 +10,7 @@ import DateUtils._
 class BookSectionPageSuite extends FunSuite {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val ta = Article(TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "").toContent)
+  val ta = Article(TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None).toContent)
 
   val articles: List[Article] = List(1, 1, 2, 2, 3).map(n => ta.copy(newspaperPageNumber = n))
 

--- a/src/test/scala/com/gu/kindlegen/BookSectionPageSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/BookSectionPageSuite.scala
@@ -15,7 +15,6 @@ class BookSectionPageSuite extends FunSuite {
   val articles: List[Article] = List(1, 1, 2, 2, 3).map(n => ta.copy(newspaperPageNumber = n))
 
   val chunkedArticles = BookSectionPage.chunkByPageNum(articles)
-  //  val BSPs = BookSectionPage.chunksToBSP(articles)
 
   test("BookSectionPage.chunkByPageNum sorts article into lists of lists by pagenum") {
     assert(BookSectionPage.chunkByPageNum(articles).map(_.map(_.newspaperPageNumber)) === List(List(1, 1), List(2, 2), List(3)))

--- a/src/test/scala/com/gu/kindlegen/BookSectionPageSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/BookSectionPageSuite.scala
@@ -10,7 +10,7 @@ import DateUtils._
 class BookSectionPageSuite extends FunSuite {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val ta = Article(TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None).toContent)
+  val ta = Article((TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0).toContent), 0)
 
   val articles: List[Article] = List(1, 1, 2, 2, 3).map(n => ta.copy(newspaperPageNumber = n))
 

--- a/src/test/scala/com/gu/kindlegen/ManifestSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ManifestSuite.scala
@@ -20,7 +20,7 @@ class SectionManifestSpec extends FlatSpec {
   //    0, "my title", "", capiDate, capiDate, capiDate, "my name", "article abstract", "content", Some("image.URL")
   //  )
   //  val articles = List(article)
-  val ta = Article(TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None).toContent)
+  val ta = Article((TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0).toContent, 0))
 
   val articles = {
     Seq(
@@ -103,12 +103,14 @@ class SectionManifestSpec extends FlatSpec {
 
   ".toSectionString" should "add `.xml` and change slash to underscore in titleLink" in {
     val sectionHeading = SectionHeading(articles.head)
-    val expectedOutput =
+
+    val expectedOutput = {
       """<item>
         | <title>International</title>
         | <link>theguardian_mainsection_international.xml</link>
         |</item>
         |""".stripMargin
+    }
     assert(sectionHeading.toSectionString === expectedOutput)
   }
 }

--- a/src/test/scala/com/gu/kindlegen/ManifestSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/ManifestSuite.scala
@@ -1,8 +1,5 @@
 package com.gu.kindlegen
 
-import org.scalatest.FunSuite
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import com.gu.contentapi.client.utils._
 import org.scalatest.FlatSpec
 import DateUtils._
@@ -11,15 +8,6 @@ import org.joda.time.DateTime
 class SectionManifestSpec extends FlatSpec {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  //  val ta = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None)
-  //  val tac = ta.toContent
-  //  val taca = Article(tac)
-  //  val article = Article(
-  //    newspaperBookSection = "theguardian/mainsection/international",
-  //    sectionName = "International",
-  //    0, "my title", "", capiDate, capiDate, capiDate, "my name", "article abstract", "content", Some("image.URL")
-  //  )
-  //  val articles = List(article)
   val ta = Article((TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0).toContent, 0))
 
   val articles = {

--- a/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
@@ -13,7 +13,7 @@ class QuerierSpec extends FlatSpec {
 
   // TODO: Find a way to test printSentResponse, extract the edition dates etc
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val testcontent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "").toContent
+  val testcontent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "", None).toContent
   val capiResponse = List(testcontent)
 
   ".responseToArticles" should "convert a capi response (Seq[Content) to a Seq[Article]" in {

--- a/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
@@ -18,6 +18,7 @@ class QuerierSpec extends FlatSpec {
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
   val testcontent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0).toContent
   val capiResponse = List(testcontent)
+  val testArticle = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0)
 
   ".responseToArticles" should "convert a capi response (Seq[Content) to a Seq[Article]" in {
     val toArticles = Querier.responseToArticles(capiResponse)
@@ -27,7 +28,6 @@ class QuerierSpec extends FlatSpec {
 
   ".sortContentByPageAndSection" should "sort content according to page number then book section" in {
 
-    val testArticle = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0)
     val contents: Seq[Content] = {
       Seq(
         ("theguardian/mainsection/topstories", 4),

--- a/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
@@ -16,7 +16,7 @@ class QuerierSpec extends FlatSpec {
   }
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val testcontent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "", None).toContent
+  val testcontent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0).toContent
   val capiResponse = List(testcontent)
 
   ".responseToArticles" should "convert a capi response (Seq[Content) to a Seq[Article]" in {
@@ -27,7 +27,7 @@ class QuerierSpec extends FlatSpec {
 
   ".sortContentByPageAndSection" should "sort content according to page number then book section" in {
 
-    val testArticle = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None)
+    val testArticle = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0)
     val contents: Seq[Content] = {
       Seq(
         ("theguardian/mainsection/topstories", 4),

--- a/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
@@ -3,22 +3,58 @@ package com.gu.kindlegen
 import com.gu.contentapi.client.utils.CapiModelEnrichment
 import org.scalatest.FlatSpec
 import DateUtils._
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.v1.TagType.NewspaperBookSection
 
 class QuerierSpec extends FlatSpec {
 
+  // TODO: Find a way to test printSentResponse, extract the edition dates etc
   // TODO: Find a way to override the source file to a sample.conf version
+
   ".readApiKey" should "read API key from external conf file" in {
     assert(Querier.readApiKey !== "test")
   }
 
-  // TODO: Find a way to test printSentResponse, extract the edition dates etc
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
   val testcontent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "", None).toContent
   val capiResponse = List(testcontent)
 
   ".responseToArticles" should "convert a capi response (Seq[Content) to a Seq[Article]" in {
     val toArticles = Querier.responseToArticles(capiResponse)
+
     assert(toArticles.head.newspaperPageNumber === 3)
   }
 
+  ".sortContentByPageAndSection" should "sort content according to page number then book section" in {
+
+    val testArticle = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None)
+    val contents: Seq[Content] = {
+      Seq(
+        ("theguardian/mainsection/topstories", 4),
+        ("theguardian/mainsection/international", 1),
+        ("theguardian/mainsection/finance", 1),
+        ("theguardian/mainsection/international", 2),
+        ("theguardian/mainsection/topstories", 3),
+        ("theguardian/mainsection/international", 3)
+      ).map {
+
+          case (l, m) => testArticle.copy(testArticleNewspaperBookSection = l, testArticlePageNumber = m).toContent
+        }
+    }
+
+    val mappedSortedContents: Seq[(String, Int)] = {
+      Seq(
+        ("theguardian/mainsection/finance", 1),
+        ("theguardian/mainsection/international", 1),
+        ("theguardian/mainsection/international", 2),
+        ("theguardian/mainsection/international", 3),
+        ("theguardian/mainsection/topstories", 3),
+        ("theguardian/mainsection/topstories", 4)
+      )
+    }
+    val mappedResult: Seq[(String, Int)] = Querier.sortContentByPageAndSection(contents).map(content => (content.tags.find(_.`type` == NewspaperBookSection).get.id, content.fields.flatMap(_.newspaperPageNumber).get))
+    println(contents.head)
+    println(mappedResult)
+    assert(mappedResult == mappedSortedContents)
+  }
 }

--- a/src/test/scala/com/gu/kindlegen/TestContent.scala
+++ b/src/test/scala/com/gu/kindlegen/TestContent.scala
@@ -1,6 +1,9 @@
 package com.gu.kindlegen
 
 import com.gu.contentapi.client.model.v1.TagType.NewspaperBookSection
+import com.gu.contentapi.client.model.v1.ElementType.Image
+import com.gu.contentapi.client.model.v1.Asset
+import com.gu.contentapi.client.model.v1.AssetType.Image
 import com.gu.contentapi.client.model.v1._
 
 /*
@@ -37,7 +40,8 @@ case class TestContent(
     // TODO: for clarity add pub-and release- dates or remove from other Article methods
     testArticleByline: String,
     testArticleAbstract: String, // standfirst is used
-    testArticleContent: String
+    testArticleContent: String,
+    testArticleImageUrl: Option[String]
 ) {
   def toContent: Content = Content(
     references = Nil,
@@ -134,7 +138,24 @@ case class TestContent(
     isHosted = false,
     webTitle = "",
     sectionId = None,
-    elements = Option(Nil),
+    elements = Option(Seq(element)),
     isExpired = None
   )
+
+  def element: Element = Element(
+    `type` = ElementType.Image,
+    relation = "main",
+    assets = Seq(asset),
+    id = "",
+    galleryIndex = None
+  )
+
+  def asset: Asset = Asset(
+    `type` = AssetType.Image,
+    typeData = Option(AssetFields(
+      width = Some(500),
+      secureFile = testArticleImageUrl
+    ))
+  )
 }
+

--- a/src/test/scala/com/gu/kindlegen/TestContent.scala
+++ b/src/test/scala/com/gu/kindlegen/TestContent.scala
@@ -37,11 +37,11 @@ case class TestContent(
     testArticleIssueDate: CapiDateTime,
     testArticleReleaseDate: CapiDateTime,
     testArticlePubDate: CapiDateTime,
-    // TODO: for clarity add pub-and release- dates or remove from other Article methods
     testArticleByline: String,
     testArticleAbstract: String, // standfirst is used
     testArticleContent: String,
-    testArticleImageUrl: Option[String]
+    testArticleImageUrl: Option[String],
+    testArticleFileID: Int
 ) {
   def toContent: Content = Content(
     references = Nil,

--- a/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
@@ -20,7 +20,7 @@ class TestContentSuite extends FunSuite {
     assert(ta.toContent.fields.flatMap(_.headline) === Some(""))
     val ta2 = ta.copy(testArticleTitle = "new title")
     assert(ta2.toContent.fields.get.headline === Some("new title"))
-    // add default args
+    // TODO: add default args?
   }
 
 }

--- a/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
@@ -10,7 +10,7 @@ import DateUtils._
 class TestContentSuite extends FunSuite {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val ta = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "")
+  val ta = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None)
 
   test("TestContent.toContent") {
     assert(ta.toContent.id === "")

--- a/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
@@ -10,7 +10,7 @@ import DateUtils._
 class TestContentSuite extends FunSuite {
 
   val capiDate = CapiModelEnrichment.RichJodaDateTime(formatter.parseDateTime("20170724")).toCapiDateTime
-  val ta = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None)
+  val ta = TestContent("", "", 1, "", "", capiDate, capiDate, capiDate, "", "", "", None, 0)
 
   test("TestContent.toContent") {
     assert(ta.toContent.id === "")


### PR DESCRIPTION
A capi Response is converted to a  Seq[Article]. Each Article contains the attribute Option(imageUrl), because there may or may not be an imageURL that corresponds to an image that meets the filtering requirements for NITF articles.

fetchImageData retrieves the images for the articles that DO have a suitable image, and is now a Future so that when pagination is added, this method can be called on, for example, the first page of capi Articles, while successive pages are being retrieved.