### PR TITLE
Produce Valid NITF

### DIFF
--- a/src/main/scala/com/gu/kindlegen/Article.scala
+++ b/src/main/scala/com/gu/kindlegen/Article.scala
@@ -1,6 +1,9 @@
 package com.gu.kindlegen
 
+import java.time.OffsetDateTime
+
 import com.gu.contentapi.client.model.v1._
+import com.gu.contentapi.client.utils.CapiModelEnrichment._
 
 
 case class Article(
@@ -9,7 +12,7 @@ case class Article(
     title: String,
     docId: String,
     link: Link,
-    pubDate: CapiDateTime,
+    pubDate: OffsetDateTime,
     byline: String,
     articleAbstract: String,
     bodyBlocks: Seq[String],
@@ -43,7 +46,7 @@ object Article {
       title = content.webTitle,
       docId = content.id,
       link = Link.AbsoluteURL.from(content.webUrl),
-      pubDate = newspaperDate,
+      pubDate = newspaperDate.toOffsetDateTime,
       byline = fields.byline.getOrElse(""),
       articleAbstract = fields.standfirst.getOrElse(""),
       // TODO handle non-text articles (e.g. cartoons)

--- a/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
+++ b/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
@@ -1,35 +1,53 @@
 package com.gu.kindlegen
 
-import DateUtils._
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
-case class ArticleNITF(fileContents: String)
+import scala.xml.Elem
+
 
 object ArticleNITF {
+  private val formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC)
+}
 
-  def apply(article: Article) = new ArticleNITF(
-    fileContents = s"""
-     |<?xml version="1.0" encoding="UTF-8"?>
-     |<nitf version="-//IPTC//DTD NITF 3.3//EN">
-     |<head>
-     |<title>${article.title}</title>
-     |<docdata management-status="usable">
-     |<doc-id id-string="${article.docId}" />
-     |<urgency ed-urg="2" />
-     |<date.issue norm="${formatDate(article.pubDate)}" />
-     |<date.release norm="${formatDate(article.pubDate)}" />
-     |<doc.copyright holder="guardian.co.uk" />
-     |</docdata>
-     |<pubdata type="print" date.publication="${formatDate(article.pubDate)}" />
-     |</head>
-     |<body>
-     |<body.head>
-     |<hedline><hl1>${article.title}</hl1></hedline>
-     |<byline>${article.byline}</byline>
-     |<abstract>${article.articleAbstract}</abstract>
-     |</body.head>
-     |<body.content>${article.bodyBlocks.mkString("\n") /* TODO convert to NITF blocks*/}</body.content>
-     |<body.end />
-     |</body>
-     |</nitf>""".stripMargin
-  )
+case class ArticleNITF(article: Article) {
+  import ArticleNITF._
+
+  def nitf: Elem = {
+    <nitf version="-//IPTC//DTD NITF 3.5//EN">
+      {head}
+      {body}
+     </nitf>
+  }
+
+  private def head = {
+    val pubDate = formatter.format(article.pubDate)
+    <head>
+      <title>{article.title}</title>
+      <docdata management-status="usable">
+        <doc-id id-string={article.docId}/>
+        <urgency ed-urg="2"/>
+        <date.release norm={pubDate}/>
+        <doc.copyright holder="guardian.co.uk"/>
+      </docdata>
+      <pubdata type="print" date.publication={pubDate}/>
+    </head>
+  }
+
+  private def body = {
+    <body>
+      <body.head>
+        <hedline>
+          <hl1>{article.title}</hl1>
+        </hedline>
+        <byline>{article.byline}</byline>
+        <abstract>{articleAbstract}</abstract>
+      </body.head>
+      <body.content>{bodyContent}</body.content>
+      <body.end/>
+    </body>
+  }
+
+  private def articleAbstract = scala.xml.Unparsed(article.articleAbstract)
+  private def bodyContent = article.bodyBlocks.map(scala.xml.Unparsed.apply) /* TODO convert to NITF blocks*/
 }

--- a/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
+++ b/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
@@ -69,11 +69,20 @@ case class ArticleNITF(article: Article) {
         <byline>{article.byline}</byline>
         <abstract>{articleAbstract}</abstract>
       </body.head>
-      <body.content>{bodyContent}</body.content>
+      <body.content>
+        {mainImage ++ bodyContent}
+      </body.content>
       <body.end/>
     </body>
   }.toElem.get)
 
   private def articleAbstract = htmlToXhtml(article.articleAbstract)
   private def bodyContent = article.bodyBlocks.map(html => <block>{htmlToXhtml(html)}</block>)
+  private def mainImage: Option[Elem] = article.mainImage.map { image =>
+    <content>
+      <img src={image.link.source}>
+        {image.caption.getOrElse("")} {image.credit.getOrElse("")}
+      </img>
+    </content>
+  }
 }

--- a/src/main/scala/com/gu/kindlegen/BookSection.scala
+++ b/src/main/scala/com/gu/kindlegen/BookSection.scala
@@ -17,7 +17,7 @@ case class BookSection(section: Section, articles: Seq[Article]) extends Linkabl
   def id: String = section.id
   def title: String = section.title
   def link: Link = section.link
-  lazy val publicationDate: LocalDate = articles.map(_.pubDate).minBy(_.dateTime).toOffsetDateTime.toLocalDate
+  lazy val publicationDate: LocalDate = articles.map(_.pubDate).min.toLocalDate
 
   def withLink(newLink: Link): BookSection = copy(section = section.copy(link = newLink))
 }

--- a/src/main/scala/com/gu/kindlegen/KindleGenerator.scala
+++ b/src/main/scala/com/gu/kindlegen/KindleGenerator.scala
@@ -76,9 +76,9 @@ class KindleGenerator(querier: Querier,
   }
 
   private def writeToFile(article: Article, fileNameIndex: Int): Article = {
-    val nitf = ArticleNITF(article)
+    val nitfGenerator = ArticleNITF(article)
     val fileName = s"${fileNameIndex}_${asFileName(article.docId)}.${fileSettings.nitfExtension}"
-    article.copy(link = writeToFile(nitf.fileContents, fileName))
+    article.copy(link = writeToFile(nitfGenerator.nitf, fileName))
   }
 
   private def writeToFile(bookSection: BookSection): BookSection = {

--- a/src/main/scala/com/gu/kindlegen/Querier.scala
+++ b/src/main/scala/com/gu/kindlegen/Querier.scala
@@ -53,5 +53,3 @@ class Querier(capiClient: PrintSentContentClient,
     }.map(_.headOption)
   }
 }
-
-// TODO: create a fileStructure model class with paths and file names.

--- a/src/main/scala/com/gu/kpp/nitf/XhtmlToNitfTransformer.scala
+++ b/src/main/scala/com/gu/kpp/nitf/XhtmlToNitfTransformer.scala
@@ -11,7 +11,7 @@ object XhtmlToNitfTransformer {
     * @return the element transformed to match NITF specs
     */
   def apply(xhtml: Elem): Elem = {
-    xhtml.transform(transformationRules).asInstanceOf[Elem]//.toElem()
+    xhtml.transform(transformationRules).toElem()
   }
 
   private def transformationRules = Seq(

--- a/src/main/scala/com/gu/kpp/nitf/XhtmlToNitfTransformer.scala
+++ b/src/main/scala/com/gu/kpp/nitf/XhtmlToNitfTransformer.scala
@@ -5,14 +5,13 @@ import scala.xml._
 import com.gu.xml._
 
 object XhtmlToNitfTransformer {
-  /** Transforms the <body> of an XHTML document into valid NITF <body.content>.
+  /** Transforms an XHTML document into valid NITF <body.content>.
     *
-    * @param xhtmlBody an element representing the <body> of an XHTML document
-    * @return an element representing the <body.content> of an equivalent NITF document
+    * @param xhtml an element representing an XHTML document
+    * @return the element transformed to match NITF specs
     */
-  def apply(xhtmlBody: Elem): Elem = {
-    val xhtml = if (xhtmlBody.label == "body") xhtmlBody.copy(label = "body.content") else xhtmlBody
-    xhtml.transform(transformationRules).toElem()
+  def apply(xhtml: Elem): Elem = {
+    xhtml.transform(transformationRules).asInstanceOf[Elem]//.toElem()
   }
 
   private def transformationRules = Seq(
@@ -47,8 +46,8 @@ object XhtmlToNitfTransformer {
   }
 
   private val convertOrRemoveTags = {
-    val mappings = Map("b" -> "strong", "h2" -> "hl2", "i" -> "em", "u" -> "em")  // apparently, Amazon handles some of these
-    val unsupportedTags = Set("figure", "span", "sub", "sup")  // TODO should we format such text? (sub and sup can be in <num>)
+    val mappings = Map("b" -> "strong", "h2" -> "hl2", "i" -> "em", "u" -> "em")
+    val unsupportedTags = Set("figure", "span", "sub", "sup")
     val unwantedTags = Set("s", "strike")  // tags that should be removed along with their content
     val nonEmptyTags = Set("note", "abstract", "dl", "fn", "ol", "tr", "ul")  // tags that must contain something
     rewriteRule("Convert or remove tags") {

--- a/src/main/scala/com/gu/xml/package.scala
+++ b/src/main/scala/com/gu/xml/package.scala
@@ -104,7 +104,7 @@ object `package` {
       * @param matches a predicate that identifies which children are to be extracted
       * @return a sequence of nodes that either match the condition or are a ''parent'' themselves
       */
-    def unwrapChildren(matches: Node => Boolean): Seq[Node] =
+    def unwrapChildren(matches: Node => Boolean): NodeSeq =
       elem.child.adaptPartitions(!matches(_),
         adaptMatching = wrappables => elem.copy(child = wrappables)
       )

--- a/src/main/scala/com/gu/xml/package.scala
+++ b/src/main/scala/com/gu/xml/package.scala
@@ -151,7 +151,7 @@ object `package` {
   }
 
   // PrettyPrinter is stateful, so we need a new instance for each concurrent call
-  implicit def defaultPrettyPrinter: PrettyPrinter = new PrettyPrinter(width = 160, step = 3)
+  implicit def defaultPrettyPrinter: PrettyPrinter = new PrettyPrinter(width = 200, step = 3)
 
   object TrimmingPrinter extends PrettyPrinter(width = Int.MaxValue, step = 0, minimizeEmpty = true) {
     override def format(n: Node, pscope: NamespaceBinding, sb: StringBuilder): Unit =

--- a/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
@@ -9,7 +9,7 @@ import com.gu.kindlegen.TestContent._
 import com.gu.xml.XmlUtils._
 
 
-class ArticleNITFSuite extends FunSpec {
+class ArticleNITFSpec extends FunSpec {
 
   describe("ArticleNITF") {
 
@@ -56,7 +56,7 @@ class ArticleNITFSuite extends FunSpec {
     }
 
     it("handles XHTML tags") {
-      val content = <p>abc</p> ++ <p>an <em>emphasised</em> word</p>
+      val content = <p>abc</p> ++ <p>an<em>emphasised</em>word</p>
 
       val article = simpleArticle.copy(bodyBlocks = Seq(content.mkString))
       val nitf = Utility.trim(ArticleNITF(article).nitf)

--- a/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
@@ -27,8 +27,8 @@ class ArticleNITFSpec extends FunSpec {
     )
 
     it("produces simple NITF") {
-      val expectedOutput =
-        <nitf version="-//IPTC//DTD NITF 3.5//EN">
+      val expectedOutput = ArticleNITF.qualify(
+        <nitf version={ArticleNITF.Version}>
           <head>
             <title>my title</title>
             <docdata management-status="usable">
@@ -45,14 +45,18 @@ class ArticleNITFSpec extends FunSpec {
                 <hl1>my title</hl1>
               </hedline>
               <byline>my name</byline>
-              <abstract>article abstract</abstract>
+              <abstract><p>article abstract</p></abstract>
             </body.head>
-            <body.content>content</body.content>
+            <body.content>
+              <block><p>content</p></block>
+            </body.content>
             <body.end/>
           </body>
         </nitf>
+      )
 
-      assertEquivalentXml(ArticleNITF(simpleArticle).nitf, expectedOutput)
+      val generated = ArticleNITF(simpleArticle).nitf
+      assertEquivalentXml(generated, expectedOutput)
     }
 
     it("handles XHTML tags") {
@@ -62,7 +66,7 @@ class ArticleNITFSpec extends FunSpec {
       val nitf = Utility.trim(ArticleNITF(article).nitf)
       val body = (nitf \\ "body.content").head.nonEmptyChildren
 
-      body.mkString shouldBe content.mkString
+      body.mkString shouldBe <block>{content}</block>.mkString
     }
   }
 }

--- a/src/test/scala/com/gu/kindlegen/BookSectionSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/BookSectionSuite.scala
@@ -4,14 +4,16 @@ import org.scalatest.FlatSpec
 import org.scalatest.Inspectors._
 import org.scalatest.Matchers._
 
+import com.gu.kindlegen.TestContent._
+
 
 class BookSectionSuite extends FlatSpec {
   private def article(sectionId: String, sectionName: String, pageNum: Int) =
     Article(section = section(sectionId, sectionName), newspaperPageNumber = pageNum,
-      "", "", TestContent.ExampleLink, TestContent.ExampleDate, "", "", Nil, None)
+      "", "", ExampleLink, ExampleOffsetDate, "", "", Nil, None)
 
   private def section(sectionId: String, sectionName: String) =
-    Section(id = sectionId, title = sectionName, link = TestContent.ExampleLink)
+    Section(id = sectionId, title = sectionName, link = ExampleLink)
 
   private val articlesInZ = (1 to 4).map(pageNum => article("z", "Z", pageNum))
   private val articlesInX = (1 to 4).map(pageNum => article("x", "X", pageNum))

--- a/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
@@ -57,7 +57,7 @@ class KindleGeneratorSpec extends FunSpec with TempFiles {
 
     it("generates valid NITF files") { pendingUntilFixed {
       forEvery(nitfFiles) { path => withClue(path) {
-        val nitf = XML.loadFile(path.toFile)  // fails due to unclosed <br> tags
+        val nitf = XML.loadFile(path.toFile)
         validateXml(nitf, resource("kpp-nitf-3.5.7.xsd").toURI)  // fails due to non-NITF tags (e.g. <i>)
       }}
     }}

--- a/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
@@ -23,8 +23,8 @@ class KindleGeneratorSpec extends FunSpec with TempFiles {
   private val deleteGeneratedFiles = conf.getBoolean("deleteGeneratedFiles")
 
   {
-    val firstDate = LocalDate.of(2018, 4, 1)
-    val lastDate = LocalDate.of(2018, 4, 1)
+    val firstDate = LocalDate.of(2018, 3, 16)
+    val lastDate = LocalDate.of(2018, 3, 17)
     (firstDate.toEpochDay to lastDate.toEpochDay).map(LocalDate.ofEpochDay).foreach(test)
   }
 
@@ -100,7 +100,7 @@ class KindleGeneratorSpec extends FunSpec with TempFiles {
       val items = xml \ "channel" \ "item" \ "link"
       items should not be empty
 
-      items.map(_.text).map(manifestPath.resolveSibling)
+      items.map(_.text.trim).map(manifestPath.resolveSibling)
     }}
 
     def assertLinkedFilesCoverAllLinkableFiles(linkedFiles: Seq[Path], linkables: Seq[Path]) = {

--- a/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
@@ -57,8 +57,8 @@ class KindleGeneratorSpec extends FunSpec with TempFiles {
 
     it("generates valid NITF files") { pendingUntilFixed {
       forEvery(nitfFiles) { path => withClue(path) {
-        val nitf = XML.loadFile(path.toFile)
-        validateXml(nitf, resource("kpp-nitf-3.5.7.xsd").toURI)
+        val nitf = XML.loadFile(path.toFile)  // fails due to unclosed <br> tags
+        validateXml(nitf, resource("kpp-nitf-3.5.7.xsd").toURI)  // fails due to non-NITF tags (e.g. <i>)
       }}
     }}
 

--- a/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
@@ -22,9 +22,6 @@ class QuerierSpec extends FlatSpec with ScalaFutures with IntegrationPatience {
 
   val totalArticles = 96  // on exampleDate = 2017-07-24
 
-  // TODO: Find a way to test printSentResponse, extract the edition dates etc
-  // TODO: Find a way to override the source file to a sample.conf version
-
   val capiDate = ExampleDate
   val testContent = TestContent("", "", 3, "", "", capiDate, capiDate, capiDate, "", "", "", None)
   val capiResponse = List(testContent.toContent)

--- a/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/QuerierSpec.scala
@@ -17,7 +17,7 @@ class QuerierSpec extends FlatSpec with ScalaFutures with IntegrationPatience {
   val settings = Settings.load.get.contentApi
   val capiClient = new PrintSentContentClient(settings) // we can mock this for local testing
 
-  private def querier: Querier = querier(ExampleDate.toOffsetDateTime.toLocalDate)
+  private def querier: Querier = querier(ExampleOffsetDate.toLocalDate)
   private def querier(editionDate: LocalDate) = new Querier(capiClient, ExampleQuerySettings, editionDate)
 
   val totalArticles = 96  // on exampleDate = 2017-07-24

--- a/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
+++ b/src/test/scala/com/gu/kindlegen/TestContentSuite.scala
@@ -19,7 +19,6 @@ class TestContentSuite extends FunSuite {
     assert(ta.toContent.fields.flatMap(_.headline) === Some(""))
     val ta2 = ta.copy(testArticleTitle = "new title")
     assert(ta2.toContent.fields.get.headline === Some("new title"))
-    // TODO: add default args?
   }
 
 }

--- a/src/test/scala/com/gu/nitf/XhtmlToNitfTransformationSpec.scala
+++ b/src/test/scala/com/gu/nitf/XhtmlToNitfTransformationSpec.scala
@@ -6,10 +6,12 @@ import java.nio.file.{Path, Paths}
 import scala.xml._
 
 import org.scalatest.FunSpec
+import org.scalatest.Matchers._
 
 import com.gu.kpp.nitf.XhtmlToNitfTransformer
 import com.gu.xml._
 import com.gu.xml.XmlUtils._
+
 
 class XhtmlToNitfTransformationSpec extends FunSpec {
   import XhtmlToNitfTransformationSpec._
@@ -25,6 +27,9 @@ class XhtmlToNitfTransformationSpec extends FunSpec {
           try {
             val xml = loadAndTransform(nitfFilePath.toFile)
             validateXml(xml, resource("kpp-nitf-3.5.7.xsd").toURI)
+
+            // the transformer should be idempotent: applying the transformation to valid NITF should do nothing
+            XhtmlToNitfTransformer(xml) shouldBe xml
           } catch {
             case e: org.xml.sax.SAXParseException =>
               e.printStackTrace()

--- a/src/test/scala/com/gu/xml/XmlUtils.scala
+++ b/src/test/scala/com/gu/xml/XmlUtils.scala
@@ -32,7 +32,8 @@ object XmlUtils {
   def assertEquivalentXml(actual: Node, expected: Node): Unit = {
     val diff = expected =#= actual
     withClue(diff.toString + "\n" + diff.errorMessage + "\n") {
-      prettify(actual) should beXml(prettify(expected), ignoreWhitespace = true)
+      // swap expected and actual because `beXml` v2.0.3 reports results in the opposite order
+      prettify(expected) should beXml(prettify(actual), ignoreWhitespace = true)
     }
   }
 


### PR DESCRIPTION
The purpose of this PR is to make sure that the NITF that we generate is valid.

We got rid of using strings and instead use scala-xml to make sure strings are properly escaped. We also use Jsoup to make sure that the HTML is valid. Finally, `XhtmlToNitfTransformer` (introduced in PRs #12 and #13) maps the XHTML to a valid NITF structure.