### PR TITLE
Simplify building artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,32 +47,12 @@ libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % 
 libraryDependencies += "com.typesafe" % "config" % "1.3.3"
 
 /* deps for Riff-Raff Guardian deployment tool */
-enablePlugins(RiffRaffArtifact)
+enablePlugins(RiffRaffArtifact, JavaAppPackaging)
 
-assemblyJarName := s"${name.value}.jar"
-riffRaffPackageType := assembly.value
+Universal / topLevelDirectory := None
+Universal / packageName := normalizedName.value
+riffRaffPackageType := (Universal / dist).value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"Off-platform::${name.value}"
 riffRaffArtifactResources += (file("cfn.yaml"), s"${name.value}-cfn/cfn.yaml")
-
-// Copied from https://github.com/guardian/content-api/blob/master/concierge/build.sbt
-assemblyMergeStrategy in assembly := {
-  case PathList("org", "joda", "time", "base", "BaseDateTime.class") => MergeStrategy.first
-  case "about.html" => MergeStrategy.discard
-  case  PathList("models", "intermediate.json") => MergeStrategy.first // Deal with aws sdk containing several time the same file
-  case  PathList("models", "model.json") => MergeStrategy.first // Deal with aws sdk containing several time the same file
-  // Two shared.thrift files. One from content-atom-models and one from content-entity models
-  // both of which are a dependency of content-api-models. We do not need the thrift files so we can exclude these
-  // to get around assembly throwing an error.
-  case  "shared.thrift" => MergeStrategy.discard
-  case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.first
-  case x =>
-    val oldStrategy = (assemblyMergeStrategy in assembly).value
-    oldStrategy(x)
-}
-
-/* for auto import in console */
-initialCommands in console += """
-  import com.gu.kindlegen._;
-"""

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -72,7 +72,7 @@ Resources:
             Schedule: cron(30 1 * * ? *)  # Run at 01:30 AM every day
       CodeUri:
         Bucket: !Ref DeployBucket
-        Key: !Sub ${Stack}/${Stage}/${App}/${App}.jar
+        Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
       Policies:
         - AWSLambdaBasicExecutionRole  # Managed Policy that includes CloudWatch log permissions
         - Statement:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -48,6 +48,7 @@ Resources:
       Handler: com.gu.kindlegen.Lambda::handler
       MemorySize: 512
       Timeout: 300
+      Tracing: Active
       Environment:
         Variables:
           ConfigSettings:
@@ -75,6 +76,7 @@ Resources:
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
       Policies:
         - AWSLambdaBasicExecutionRole  # Managed Policy that includes CloudWatch log permissions
+        - AWSXrayWriteOnlyAccess       # Managed Policy that enables X-Ray telemetry
         - Statement:
             Effect: Allow
             Action:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.4
+sbt.version=1.1.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -10,7 +10,7 @@ deployments:
     parameters:
       bucket: content-api-dist
       functionNames: [kindle-gen-]
-      fileName: kindle-gen.jar
+      fileName: kindle-gen.zip
       prefixStack: false
 #    dependencies: [kindle-gen-cfn]
 


### PR DESCRIPTION
Replace sbt-assembly with sbt-native-packager. Avoid the need for a merge strategy; let the classpath loader manage similarly-named files.