### PR TITLE
Upgrade Jackson to fix a security vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ scalacOptions ++= Seq(
 autoAPIMappings := true
 doc / exportJars := true
 
+val jacksonVersion = "2.9.5"
 val log4jVersion = "2.11.0"
 val scalaXmlVersion = "1.1.0"
 
@@ -45,7 +46,7 @@ libraryDependencies ++= Seq(
   // AWS
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.1.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.330",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.335",
 
   // test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
@@ -53,6 +54,9 @@ libraryDependencies ++= Seq(
 )
 
 dependencyOverrides ++= Seq(
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,  // AWS depends on an old, insecure version
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "org.slf4j" % "slf4j-api" % "1.7.25" /* log4js-slf4j-impl depends on 1.8.0, but that's only compatible with Java 9+ */,
 )
 


### PR DESCRIPTION
The AWS SDK depends on Jackson for JSON (de)serialization. It depends on the (old) 2.6.x branch to maintain compatibility with Java 6.

At the time of writing, the AWS SDK depends on jackson-databind v2.6.7.1. This version suffers from [CVE 2017-15095](https://nvd.nist.gov/vuln/detail/CVE-2017-15095) (as [reported by Snyk](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-32111)). A fix was implemented in FasterXML/jackson-databind#1945. However, v2.6.7.2 hasn't been released yet.

The fix is currently released in v2.8.11.1 and v2.9.5. In theory, all 2.x releases should be backwards-compatible.

To confirm that the upgrade to 2.9.5 works correctly, I upgraded it in [aws-java-sdk](https://github.com/aws/aws-sdk-java) and ran the tests, all of which passed.