### PR TITLE
Fix a bug where spaces around link anchors were lost

### DIFF
--- a/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
+++ b/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
@@ -76,7 +76,7 @@ case class ArticleNITF(article: Article) {
     </head>
   }
 
-  private def body = transform(Utility.trim {
+  private def body = transform {
     <body>
       <body.head>
         <hedline>
@@ -90,7 +90,7 @@ case class ArticleNITF(article: Article) {
       </body.content>
       <body.end/>
     </body>
-  }.toElem.get)
+  }
 
   private def articleAbstract = htmlToXhtml(article.articleAbstract)
   private def bodyContent = article.bodyBlocks.map(html => <block>{htmlToXhtml(html)}</block>)


### PR DESCRIPTION
As an example, the following HTML:
```html
<p>Orbital play <a>Brighton Racecourse</a> on 29 June and <a>Zebedee’s Yard, Hull,</a> on 30 June. <a>Then touring</a> until 10 August.</p>
```
used to result in:
```html
<p>Orbital play BrightonRacecourseon 29 June andZebedee’s Yard, Hull, on 30 June.Then touringuntil 10 August.</p>
```
This was caused by the call to `Utility.trim`. We used to trim the input so that we won't wrap the spaces between XML tags (e.g. `<body> <body.content>`) in paragraphs. This commit fixes the logic that would have caused the incorrect wrapping in the first place.