### PR TITLE
Fix a bug where spaces were lost when using compact printing

### DIFF
--- a/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
@@ -67,5 +67,16 @@ class ArticleNITFSpec extends FunSpec {
 
       body.mkString shouldBe <block>{content}</block>.mkString
     }
+
+    it("removes links and preserves whitespaces") {
+      val article = simpleArticle.copy(bodyBlocks = Seq(
+        """<p>This is <a href="http://example.com">an example</a>""" +
+        """ that contains <a href="https://elsewhere.net">some links</a>.</p>"""
+      ))
+
+      val nitf = ArticleNITF(article).nitf
+      val paragraph = nitf \\ "body.content" \\ "p"
+      paragraph.mkString shouldBe "<p>This is an example that contains some links.</p>"
+    }
   }
 }

--- a/src/test/scala/com/gu/xml/XmlSpec.scala
+++ b/src/test/scala/com/gu/xml/XmlSpec.scala
@@ -1,0 +1,21 @@
+package com.gu.xml
+
+import scala.xml.{Elem, Text}
+
+import org.scalatest.FunSpec
+import org.scalatest.Matchers._
+
+
+class XmlSpec extends FunSpec {
+  describe("TrimmingPrinter") {
+    it("compacts input") {
+      val xml = <a> <b>  <c>   </c>    <d/>     </b></a>
+      TrimmingPrinter.format(xml) shouldBe "<a><b><c/><d/></b></a>"
+    }
+
+    it("maintains spaces inside contiguous text nodes") {
+      val xml = <a/>.copy(child = Seq("   ", "Some ", "text", " with", " spaces ", "...", "   ").map(Text.apply))
+      TrimmingPrinter.format(xml) shouldBe "<a>Some text with spaces ...</a>"
+    }
+  }
+}


### PR DESCRIPTION
The bug is fixed in the master branch of scala-xml (scala/scala-xml#113).

This is a continuation of PR #32.