### PR TITLE
Cartoons and Bylines

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ libraryDependencies ++= Seq(
 
   // test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
+  "org.scalamock" %% "scalamock" % "4.1.0" % "test",
   "com.github.andyglow" %% "scala-xml-diff" % "2.0.3" % "test",
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -30,8 +30,8 @@ libraryDependencies ++= Seq(
   "com.iheart" %% "ficus" % "1.4.3",
 
   // HTTP client
-  "com.softwaremill.sttp" %% "okhttp-backend" % "1.2.0-RC6",
-  "com.softwaremill.sttp" %% "json4s" % "1.2.0-RC6",
+  "com.softwaremill.sttp" %% "okhttp-backend" % "1.2.1",
+  "com.softwaremill.sttp" %% "json4s" % "1.2.1",
 
   // HTML parsing, cleanup, and conversion to NITF XML
   "org.jsoup" % "jsoup" % "1.11.3",

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -52,7 +52,7 @@ Resources:
       FunctionName: !Sub ${App}-${Stage}
       Description: Converting content to NITF format
       Runtime: java8
-      Handler: com.gu.kindlegen.Lambda::handler
+      Handler: com.gu.kindlegen.app.Lambda::handler
       MemorySize: 3008  # We usually use < 300 MB of RAM. However, we're I/O-bound so increasing cores improves speed drastically.
       Timeout: 300
       Tracing: Active

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,13 @@ content-api {
 
 gu-capi {
   sectionTagType = "NewspaperBookSection"  // equal to TagType#name
+  cartoonTags = [
+    { id = "type/cartoon", type = "Type" }
+    { id = "tone/cartoons", type = "Tone" }
+    { id = "commentisfree/series/guardian-comment-cartoon", type = "Series" }
+    { id = "commentisfree/series/observer-comment-cartoon", type = "Series" }
+  ]
+
   downloadTimeout = 4 minutes  // downloading large images can takes a long time
   maxImageResolution = 2000
 }

--- a/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
+++ b/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
@@ -3,7 +3,6 @@ package com.gu.kindlegen
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
-import scala.util.{Failure, Try}
 import scala.util.control.NonFatal
 import scala.xml._
 
@@ -82,7 +81,7 @@ case class ArticleNITF(article: Article) {
         <hedline>
           <hl1>{article.title}</hl1>
         </hedline>
-        <byline>{article.byline}</byline>
+        <byline>{nonEmpty(article.byline.trim, ifEmpty = "–")}</byline>
         <abstract>{articleAbstract}</abstract>
       </body.head>
       <body.content>
@@ -108,4 +107,6 @@ case class ArticleNITF(article: Article) {
         throw new TransformationException(s"Failed to generate NITF for <${elem.label}> in article ${article.id}: $error", error)
     }
   }
+
+  private def nonEmpty(str: String, ifEmpty: String) = if (str.nonEmpty) str else ifEmpty
 }

--- a/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
+++ b/src/main/scala/com/gu/kindlegen/ArticleNITF.scala
@@ -96,7 +96,7 @@ case class ArticleNITF(article: Article) {
   private def bodyContent = article.bodyBlocks.map(html => <block>{htmlToXhtml(html)}</block>)
   private def mainImage = article.mainImage.map { image =>
       <img src={image.link.source}>
-        {htmlToXhtml((image.caption ++ image.credit).mkString(" "), textCleaner)}  {/* TODO should we show article.trailText? */}
+        {htmlToXhtml((image.caption ++ image.credit).mkString(" "), textCleaner)}
       </img>
   }
 

--- a/src/main/scala/com/gu/kindlegen/app/Settings.scala
+++ b/src/main/scala/com/gu/kindlegen/app/Settings.scala
@@ -113,7 +113,7 @@ object WeatherSectionsReader extends ValueReader[Map[DayOfWeek, Section]] {
 
     val dailySections = config.as[Map[String, Section]](path)
       .map {
-        case (dayName, section) => Try(DayOfWeek.valueOf(dayName)).toOption -> section
+        case (dayName, section) => Try(DayOfWeek.valueOf(dayName.toUpperCase)).toOption -> section
       }
 
     val defaultSection = dailySections(None)

--- a/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
@@ -7,6 +7,23 @@ import com.gu.io.Link.AbsoluteURL
 import com.gu.kindlegen.{Section, _}
 
 
+object ArticleFactory {
+  /** Content fields processed by this factory
+    * @see [[com.gu.contentapi.client.model.v1.Content.fields]]
+    */
+  val ContentFields = Set("byline", "newspaper-edition-date", "newspaper-page-number", "standfirst")
+
+  /** Content blocks processed by this factory
+    * @see [[com.gu.contentapi.client.model.v1.Content.blocks]]
+    */
+  val Blocks = Set("body")
+
+  /** Content element types processed by this factory
+    * @see [[com.gu.contentapi.client.model.v1.Content.elements]]
+    */
+  val ElementTypes = Set[ElementType](ElementType.Image)
+}
+
 class ArticleFactory(settings: GuardianProviderSettings) {
   def apply(content: Content): Article = {
     val sectionTagType = settings.sectionTagType

--- a/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
@@ -24,24 +24,9 @@ object ArticleFactory {
     * @see [[com.gu.contentapi.client.model.v1.Content.elements]]
     */
   val ElementTypes = Set[ElementType](ElementType.Image)
-
-  private def tag(id: String, tagType: TagType): Tag =
-    Tag(id, tagType, webTitle = "", webUrl = "", apiUrl = "")
-
-  // TODO move to settings
-  private[capi] val cartoonTags = Set(
-    tag("type/cartoon", TagType.Type),
-    tag("tone/cartoons", TagType.Tone),
-    tag("commentisfree/series/guardian-comment-cartoon", TagType.Series),
-    tag("commentisfree/series/observer-comment-cartoon", TagType.Series),
-  )
-
-  private[capi] val cartoonTagIds = cartoonTags.map(_.id)
 }
 
 class ArticleFactory(settings: GuardianProviderSettings, imageFactory: ImageFactory) extends Logging {
-  import com.gu.kindlegen.capi.ArticleFactory._
-
   def apply(content: Content): Article = {
     val sectionTagType = settings.sectionTagType
     val maybeSectionTag = content.tags.find(_.`type` == sectionTagType)
@@ -91,4 +76,6 @@ class ArticleFactory(settings: GuardianProviderSettings, imageFactory: ImageFact
 
   private def sectionFrom(tag: Tag): Section =
     Section(tag.id, tag.webTitle, AbsoluteURL.from(tag.webUrl))
+
+  private val cartoonTagIds: Set[String] = settings.cartoonTags.map(_.id)
 }

--- a/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
@@ -52,6 +52,12 @@ class ArticleFactory(settings: GuardianProviderSettings, imageFactory: ImageFact
     val captionFallback = if (isCartoon) content.fields.flatMap(_.trailText) else None
     val mainImage = imageFactory.mainImage(content, captionFallback)
 
+    val bodyBlocks = getBodyBlocks(content).map(_.trim)
+    val byline = fields.byline.map(_.trim).filter(_.nonEmpty).orElse {
+      if (isCartoon || bodyBlocks.forall(_.isEmpty)) mainImage.flatMap(_.credit)
+      else None
+    }
+
     Article(
       id = content.id,
       title = content.webTitle,
@@ -59,9 +65,9 @@ class ArticleFactory(settings: GuardianProviderSettings, imageFactory: ImageFact
       pageNumber = fields.newspaperPageNumber.getOrElse(Int.MaxValue),  // move to the end of the section
       link = Link.AbsoluteURL.from(content.webUrl),
       pubDate = newspaperDate.toOffsetDateTime,
-      byline = fields.byline.getOrElse(""),
+      byline = byline.getOrElse(""),
       articleAbstract = fields.standfirst.getOrElse(""),
-      bodyBlocks = getBodyBlocks(content),
+      bodyBlocks = bodyBlocks,
       mainImage = mainImage
     )
   }

--- a/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
@@ -43,7 +43,7 @@ class GuardianArticlesProvider(capiClient: ContentApiClient,
 
   def fetchPrintSentResponse(): Future[SearchResponse] = {
     import ArticleFactory.{Blocks, ContentFields, ElementTypes}
-    val tagTypes = ArticleFactory.cartoonTags.map(_.`type`) + settings.sectionTagType // TODO move to settings
+    val tagTypes = settings.cartoonTags.map(_.`type`) + settings.sectionTagType
     val query = KindlePublishingSearchQuery(editionDate, Blocks, ElementTypes, ContentFields, tagTypes)
     logger.debug(s"Querying CAPI: ${capiClient.url(query)}")
     capiClient.getResponse(query)

--- a/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
@@ -43,7 +43,8 @@ class GuardianArticlesProvider(capiClient: ContentApiClient,
 
   def fetchPrintSentResponse(): Future[SearchResponse] = {
     import ArticleFactory.{Blocks, ContentFields, ElementTypes}
-    val query = KindlePublishingSearchQuery(editionDate, Blocks, ElementTypes, ContentFields, Set(settings.sectionTagType))
+    val tagTypes = ArticleFactory.cartoonTags.map(_.`type`) + settings.sectionTagType // TODO move to settings
+    val query = KindlePublishingSearchQuery(editionDate, Blocks, ElementTypes, ContentFields, tagTypes)
     logger.debug(s"Querying CAPI: ${capiClient.url(query)}")
     capiClient.getResponse(query)
   }
@@ -83,5 +84,5 @@ class GuardianArticlesProvider(capiClient: ContentApiClient,
       logger.fatal("Failed to query CAPI!", error)
   }
 
-  private val articleFactory = new ArticleFactory(settings)
+  private val articleFactory = new ArticleFactory(settings, new ImageFactory(settings))
 }

--- a/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
@@ -42,7 +42,8 @@ class GuardianArticlesProvider(capiClient: ContentApiClient,
       .map(response => articles(response.results))
 
   def fetchPrintSentResponse(): Future[SearchResponse] = {
-    val query = KindlePublishingSearchQuery(editionDate, responseTagTypes = Seq(settings.sectionTagType))
+    import ArticleFactory.{Blocks, ContentFields, ElementTypes}
+    val query = KindlePublishingSearchQuery(editionDate, Blocks, ElementTypes, ContentFields, Set(settings.sectionTagType))
     logger.debug(s"Querying CAPI: ${capiClient.url(query)}")
     capiClient.getResponse(query)
   }

--- a/src/main/scala/com/gu/kindlegen/capi/ImageFactory.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/ImageFactory.scala
@@ -6,7 +6,8 @@ import com.gu.kindlegen.Image
 
 
 class ImageFactory(settings: GuardianProviderSettings) {
-  def mainImage(content: Content): Option[Image] = {
+  def mainImage(content: Content,
+                captionFallback: Option[String] = None): Option[Image] = {
     def isMainImage(e: Element): Boolean =
       e.`type` == ElementType.Image && e.relation == "main"
 
@@ -25,11 +26,12 @@ class ImageFactory(settings: GuardianProviderSettings) {
       url <- metadata.secureFile
       absoluteUrl <- Link.AbsoluteURL(url).toOption
     } yield {
+      val caption = (metadata.caption ++ captionFallback).map(_.trim).find(_.nonEmpty)
       Image(
         id = mainImage.id,
         link = absoluteUrl,
         altText = metadata.altText,
-        caption = metadata.caption,
+        caption = caption,
         credit = if (metadata.displayCredit.getOrElse(true)) metadata.credit else None
       )
     }

--- a/src/main/scala/com/gu/kindlegen/capi/KindlePublishingSearchQuery.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/KindlePublishingSearchQuery.scala
@@ -1,13 +1,12 @@
 package com.gu.kindlegen.capi
 
 import java.time.{LocalDate, ZoneOffset}
-import java.time.temporal.ChronoUnit.DAYS
 
 import com.gu.contentapi.client.model.PrintSentSearchQuery
-import com.gu.contentapi.client.model.v1.TagType
+import com.gu.contentapi.client.model.v1.{ElementType, TagType}
 
 object KindlePublishingSearchQuery {
-  // pagination is not necessary nor desired for a print-sent query
+  // pagination is neither necessary nor desired for a print-sent query
   // it only makes it slower and there are only ~200 per day
   // additionally, `newspaper-edition` date is always set to midnight, resulting in duplicate results across pages
   val MaxResultsPageSize = 400  // maximum page size accepted by CAPI
@@ -15,28 +14,29 @@ object KindlePublishingSearchQuery {
   val WhiteListedTags = Seq.empty[String]  // leave empty to get all tags
   val BlackListedTags = Seq("type/interactive")
 
-  val ResponseFields = Seq("byline", "newspaper-edition-date", "newspaper-page-number", "standfirst")
 
   def apply(date: LocalDate,
-            publishingZone: ZoneOffset = ZoneOffset.UTC,
-            responseTagTypes: Seq[TagType] = Nil,
+            showBlocks: Set[String],
+            showElements: Set[ElementType],
+            showFields: Set[String],
+            showTagTypes: Set[TagType],
             whiteListedTags: Seq[String] = WhiteListedTags,
             blackListedTags: Seq[String] = BlackListedTags): PrintSentSearchQuery = {
-    val startOfDay = date.atStartOfDay.toInstant(publishingZone)
-    val endOfDay = startOfDay.plus(1, DAYS).minusNanos(1)
+
+    val newspaperEditionDate = date.atStartOfDay.toInstant(ZoneOffset.UTC)
 
     PrintSentSearchQuery()
       .tag(combineParams(WhiteListedTags ++ negate(BlackListedTags)))
-      .fromDate(startOfDay)
-      .toDate(endOfDay)
+      .fromDate(newspaperEditionDate)
+      .toDate(newspaperEditionDate)
       .useDate("newspaper-edition")
-      .showBlocks("body")
-      .showElements("image")
-      .showTags(combineParams(responseTagTypes.map(_.id)))
-      .showFields(combineParams(ResponseFields))
+      .showBlocks(combineParams(showBlocks.map(_.toLowerCase)))
+      .showElements(combineParams(showElements.map(_.name.toLowerCase)))
+      .showTags(combineParams(showTagTypes.map(_.id)))
+      .showFields(combineParams(showFields))
       .pageSize(MaxResultsPageSize)
   }
 
-  @inline private def combineParams(strings: Seq[String]) = strings.mkString(",")
-  @inline private def negate(strings: Seq[String]) = strings.map("-" + _)
+  @inline private def combineParams(strings: Iterable[String]) = strings.mkString(",")
+  @inline private def negate(strings: Iterable[String]) = strings.map("-" + _)
 }

--- a/src/main/scala/com/gu/kindlegen/capi/Settings.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/Settings.scala
@@ -2,11 +2,12 @@ package com.gu.kindlegen.capi
 
 import scala.concurrent.duration.FiniteDuration
 
-import com.gu.contentapi.client.model.v1.TagType
+import com.gu.contentapi.client.model.v1.{Tag, TagType}
 
 
 final case class ContentApiCredentials(key: String, url: String)
 
 final case class GuardianProviderSettings(downloadTimeout: FiniteDuration,
+                                          maxImageResolution: Int,
                                           sectionTagType: TagType,
-                                          maxImageResolution: Int)
+                                          cartoonTags: Set[Tag])

--- a/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
@@ -258,12 +258,16 @@ object SettingsSpec {
       validateValues(article, weatherArticleValues(index))
     }
 
-    val weatherSections = this.weatherSections.map { case (day, section) => day.toUpperCase -> section }
+    val weatherSections = this.weatherSections.collect { case (day, section) if day != "default" => day.toUpperCase -> section }
     val sectionKeys = weatherSections.keySet  // day names + "default"
 
     forEvery(weather.sections) { case (day, section) =>
       section shouldBe weatherSections(day.toString)
     }
+    forEvery(weatherSections) { case (dayName, section) =>
+      weather.sections(DayOfWeek.valueOf(dayName)) shouldBe section
+    }
+
     forEvery(DayOfWeek.values.filterNot(day => sectionKeys.contains(day.toString))) { unconfiguredDay =>
       weather.sections(unconfiguredDay) shouldBe defaultSection
     }

--- a/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.Inspectors._
 import org.scalatest.Matchers._
 
 import com.gu.config.ConfigReader
-import com.gu.contentapi.client.model.v1.TagType
+import com.gu.contentapi.client.model.v1.{Tag, TagType}
 import com.gu.io.Link.AbsoluteURL
 import com.gu.kindlegen._
 import com.gu.kindlegen.accuweather.AccuWeatherSettings
@@ -112,11 +112,16 @@ object SettingsSpec {
     "downloadImages" -> "on",
   )
 
+  private val cartoonTags = (1 to 3).map { i => Tag(s"tag$i", TagType(i), apiUrl = "", webUrl = "", webTitle = "")}
   private val sectionTagType = TagType.Keyword
   private val capiValues = Map(
     "downloadTimeout" -> Duration.ofSeconds(30),
     "maxImageResolution" -> 500,
-    "sectionTagType" -> sectionTagType.name
+    "sectionTagType" -> sectionTagType.name,
+    "cartoonTags" -> cartoonTags.map { tag => Map(
+      "id" -> tag.id,
+      "type" -> tag.`type`.name
+    ).toConfigObj }.asJava
   )
 
   private val runValues = Map(
@@ -233,6 +238,7 @@ object SettingsSpec {
     Duration.ofNanos(providerSettings.downloadTimeout.toNanos) shouldBe capiValues("downloadTimeout")
     providerSettings.maxImageResolution shouldBe capiValues("maxImageResolution")
     providerSettings.sectionTagType shouldBe sectionTagType
+    providerSettings.cartoonTags should contain theSameElementsAs cartoonTags
   }
 
   private def validateValues(runSettings: RunSettings): Assertion = {

--- a/src/test/scala/com/gu/kindlegen/capi/ArticleFactorySpec.scala
+++ b/src/test/scala/com/gu/kindlegen/capi/ArticleFactorySpec.scala
@@ -53,7 +53,7 @@ class ArticleFactorySpec extends FunSpec with MockFactory {
     describe("when processing cartoons") {
       val contentWithoutCaption = contentWithTrailText.adjustAssetFields(_.copy(caption = None))
 
-      ArticleFactory.cartoonTags.foreach { tag =>
+      settings.cartoonTags.foreach { tag =>
         describe(s"with tag ${tag.id}") {
           def cartoon(content: Content) = content.copy(tags = content.tags :+ tag)
 

--- a/src/test/scala/com/gu/kindlegen/capi/ArticleFactorySpec.scala
+++ b/src/test/scala/com/gu/kindlegen/capi/ArticleFactorySpec.scala
@@ -1,33 +1,70 @@
 package com.gu.kindlegen.capi
 
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.FunSpec
 import org.scalatest.Matchers._
 
 import com.gu.contentapi.client.model.v1.Content
 import com.gu.contentapi.client.utils.CapiModelEnrichment._
+import com.gu.kindlegen.Image
+import com.gu.kindlegen.TestData._
+import com.gu.kindlegen.capi.TestContent._
 
 
-class ArticleFactorySpec extends FunSpec {
+class ArticleFactorySpec extends FunSpec with MockFactory {
+  private val settings: GuardianProviderSettings = ExampleGuardianProviderSettings
+
   describe("reading from Content") {
-    val factory = new ArticleFactory(TestContent.ExampleGuardianProviderSettings)
-    def articleFrom(content: Content) = factory(content)
-
-    val content = TestContent.Sample
-    val article = articleFrom(content.toContent)
+    val testContent = TestContent.Sample
+    lazy val factory = new ArticleFactory(settings, stub[ImageFactory])
+    lazy val article = factory(testContent.toContent)
 
     it("extracts simple fields") {
-      article.id shouldBe content.id
-      article.title shouldBe content.title
-      article.byline shouldBe content.byline
-      article.articleAbstract shouldBe content.standFirst
-      article.pageNumber shouldBe content.pageNumber
-      article.pubDate shouldBe content.issueDate.toOffsetDateTime
+      article.id shouldBe testContent.id
+      article.title shouldBe testContent.title
+      article.byline shouldBe testContent.byline
+      article.articleAbstract shouldBe testContent.standFirst
+      article.pageNumber shouldBe testContent.pageNumber
+      article.pubDate shouldBe testContent.issueDate.toOffsetDateTime
     }
 
     it("extracts section information") {
-      article.section.id shouldBe content.sectionTag.id
-      article.section.title shouldBe content.sectionTag.webTitle
-      article.section.link.source shouldBe content.sectionTag.webUrl
+      article.section.id shouldBe testContent.sectionTag.id
+      article.section.title shouldBe testContent.sectionTag.webTitle
+      article.section.link.source shouldBe testContent.sectionTag.webUrl
+    }
+  }
+
+  describe("with images") {
+    val contentWithTrailText = TestContent.Sample.toContent.adjustFields(_.copy(trailText = Some("trailText")))
+
+    def factories: (ImageFactory, ArticleFactory) = {
+      val imageFactory = mock[ImageFactory]
+      (imageFactory, new ArticleFactory(settings, imageFactory))
+    }
+
+    it("attempts to read the image") {
+      val (imageFactory, articleFactory) = factories
+
+      imageFactory.mainImage _ expects (*, None)
+      articleFactory(contentWithTrailText)
+    }
+
+    describe("when processing cartoons") {
+      val contentWithoutCaption = contentWithTrailText.adjustAssetFields(_.copy(caption = None))
+
+      ArticleFactory.cartoonTags.foreach { tag =>
+        describe(s"with tag ${tag.id}") {
+          def cartoon(content: Content) = content.copy(tags = content.tags :+ tag)
+
+          it("uses trail text for the caption fallback") {
+            val (imageFactory, articleFactory) = factories
+
+            imageFactory.mainImage _ expects (*, Some("trailText"))
+            articleFactory(cartoon(contentWithoutCaption))
+          }
+        }
+      }
     }
   }
 }

--- a/src/test/scala/com/gu/kindlegen/capi/TestContent.scala
+++ b/src/test/scala/com/gu/kindlegen/capi/TestContent.scala
@@ -40,6 +40,18 @@ object TestContent {
       width = Some(ExampleGuardianProviderSettings.maxImageResolution),
     ))
   )
+
+  implicit class RichCapiContent(val content: Content) extends AnyVal {
+    def adjustFields(newFields: ContentFields => ContentFields): Content = {
+      content.copy(fields = content.fields.map(newFields))
+    }
+
+    def adjustAssetFields(newAssetFields: AssetFields => AssetFields): Content = {
+      content.copy(elements = content.elements.map(_.map { element =>
+        element.copy(assets = element.assets.map(asset => asset.copy(typeData = asset.typeData.map(newAssetFields))))
+      }))
+    }
+  }
 }
 
 case class TestContent(id: String,

--- a/src/test/scala/com/gu/kindlegen/capi/TestContent.scala
+++ b/src/test/scala/com/gu/kindlegen/capi/TestContent.scala
@@ -8,7 +8,12 @@ import com.gu.kindlegen.TestData._
 
 
 object TestContent {
-  val ExampleGuardianProviderSettings = GuardianProviderSettings(1.minute, TagType.NewspaperBookSection, maxImageResolution = 1000)
+  val ExampleGuardianProviderSettings = GuardianProviderSettings(
+    downloadTimeout = 1.minute,
+    maxImageResolution = 1000,
+    sectionTagType = TagType.NewspaperBookSection,
+    cartoonTags = (1 to 3).map(i => Tag(s"cartoon/tag/$i", TagType(i), apiUrl = "", webUrl = "", webTitle = "")).toSet
+  )
 
   val Sample =
     TestContent("sample-article", "Sample Article", "sample-section", 0, ExampleDate.toCapiDateTime,


### PR DESCRIPTION
* Use trail text for cartoon captions if a caption isn't provided
* Set the byline of all articles, falling back to a dash. The byline is required. If it's empty then Kindle will show "No byline".