### PR TITLE
Create a stable S3 path to the current issue

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -36,6 +36,10 @@ Parameters:
     Description: The bucket where the output (NITF files) should be stored
     Type: String
     Default: kindle-gen-published-files
+  PublicDirectory:
+    Description: The publicly accessible prefix through which the published files will be available after every run
+    Type: String
+    Default: CurrentIssue
   CustomConfig:
     Description: 'Overrides application configuration settings. Should be in JSON format.'
     Type: String
@@ -53,7 +57,7 @@ Resources:
       Description: Converting content to NITF format
       Runtime: java8
       Handler: com.gu.kindlegen.app.Lambda::handler
-      MemorySize: 3008  # We usually use < 300 MB of RAM. However, we're I/O-bound so increasing cores improves speed drastically.
+      MemorySize: 3008  # We usually use < 384 MB of RAM. However, we're I/O-bound so increasing cores improves speed drastically.
       Timeout: 300
       Tracing: Active
       Environment:
@@ -71,7 +75,8 @@ Resources:
                 },
                 "s3": {
                   "bucket": "${OutputBucket}",
-                  "prefix": "${Stage}/"
+                  "prefix": "${Stage}",
+                  "publicDirectory": "${Stage}/${PublicDirectory}"
                 },
                 ${CustomConfig}
               }
@@ -95,3 +100,9 @@ Resources:
             Action:
               - s3:PutObject
             Resource: !Sub "arn:aws:s3:::${OutputBucket}/${Stage}/*"
+        - Statement:
+            Effect: Allow
+            Action:
+              - s3:GetBucketWebsite
+              - s3:PutBucketWebsite
+            Resource: !Sub "arn:aws:s3:::${OutputBucket}"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -75,7 +75,7 @@ weather {
   articles = [
     {
       title = "UK & Ireland Weather"
-      byline = "Powered by AccuWeather"
+      byline = "AccuWeather"
       pageNumber = 1000  // after any other weather articles
       cities = [
         "Belfast"
@@ -98,7 +98,7 @@ weather {
     }
     {
       title = "International Weather"
-      byline = "Powered by AccuWeather"
+      byline = "AccuWeather"
       pageNumber = 1001
       cities = [
         "Beijing"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -51,6 +51,7 @@ run {
 s3 {
   bucket = ""  // must be set to use S3
   prefix = ""
+  publicDirectory = ""
   tmpDirOnDisk = ${publishing.files.outputDir}
 }
 

--- a/src/main/scala/com/gu/io/aws/S3Publisher.scala
+++ b/src/main/scala/com/gu/io/aws/S3Publisher.scala
@@ -1,10 +1,12 @@
 package com.gu.io.aws
 
+import java.util
 import java.nio.file.Path
 
 import scala.concurrent.{ExecutionContext, Future}
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{BucketWebsiteConfiguration, RedirectRule, RoutingRule, RoutingRuleCondition}
 import org.apache.logging.log4j.scala.Logging
 
 import com.gu.io.{FilePublisher, Link, Publisher}
@@ -19,6 +21,7 @@ trait S3PublisherSettings {
   val absolutePath: AbsolutePath = AbsolutePath.from(s"/$bucketName/$bucketDirectory")
 }
 
+
 case class S3Publisher(s3: AmazonS3, settings: S3PublisherSettings)
                       (implicit ec: ExecutionContext) extends Publisher with Logging {
   logger.trace(s"Initialised with $settings")
@@ -26,10 +29,16 @@ case class S3Publisher(s3: AmazonS3, settings: S3PublisherSettings)
 
   private val tmpPublisher = FilePublisher(tmpDirOnDisk.resolve(bucketDirectory))
 
+  private lazy val websiteConfig =
+    Option(s3.getBucketWebsiteConfiguration(bucketName)).getOrElse(new BucketWebsiteConfiguration())
+
+  private lazy val routingRules =
+    Option(websiteConfig.getRoutingRules).getOrElse(new util.ArrayList[RoutingRule](1))
+
   override def persist(content: Array[Byte], fileName: String): Future[Link] = {
-    // write the file to disk temporarily; the S3 client API for files infers the metadata automatically
+    // write the file to disk temporarily; the S3 client API infers the metadata from files automatically
     tmpPublisher.persist(content, fileName).map { relativePath =>
-      val s3Path = s"$bucketDirectory/$fileName"
+      val s3Path = normalizeDir(bucketDirectory) + fileName
 
       logger.debug(s"Uploading $fileName to $s3Path...")
       s3.putObject(bucketName, s3Path, relativePath.toPath.toFile)
@@ -41,8 +50,38 @@ case class S3Publisher(s3: AmazonS3, settings: S3PublisherSettings)
     }
   }
 
-  override def publish(): Future[Unit] = {
-    // TODO mark `bucketDirectory` for publishing
-    super.publish()
+  /** Redirects publicDirectory to settings.bucketDirectory */
+  def redirect(publicDirectory: String) = Future {
+    removeRedirect(publicDirectory)
+    routingRules.add(redirectRule(publicDirectory, bucketDirectory))
+    publishRedirects()
+  }
+
+  /** Removed the redirect from publicDirectory, if any */
+  def undirect(publicDirectory: String) = Future {
+    if (removeRedirect(publicDirectory))
+      publishRedirects()
+  }
+
+  private def removeRedirect(publicDirectory: String): Boolean = {
+    val publicDir = normalizeDir(publicDirectory)
+    routingRules.removeIf(publicDir == _.getCondition.getKeyPrefixEquals)
+  }
+
+  private def publishRedirects() = {
+    websiteConfig.setRoutingRules(routingRules)
+    s3.setBucketWebsiteConfiguration(bucketName, websiteConfig)
+  }
+
+  private def redirectRule(fromDirectory: String, toDirectory: String) = {
+    val fromDir = normalizeDir(fromDirectory)
+    val toDir = normalizeDir(toDirectory)
+    new RoutingRule()
+      .withCondition(new RoutingRuleCondition().withKeyPrefixEquals(fromDir))
+      .withRedirect(new RedirectRule().withReplaceKeyPrefixWith(toDir))
+  }
+
+  private def normalizeDir(dirName: String): String = {
+    if (dirName.endsWith("/")) dirName else s"$dirName/"
   }
 }

--- a/src/main/scala/com/gu/kindlegen/KindleGenerator.scala
+++ b/src/main/scala/com/gu/kindlegen/KindleGenerator.scala
@@ -38,7 +38,7 @@ class KindleGenerator(provider: ArticlesProvider,
   }
 
   // this implementation fails if any of the operations fails
-  // we might want to modify that so that failed operations, e.g. downloading an image, don't affect other operations
+  // we might want to modify that so that failed operations don't affect other operations
   def publish(): Future[Unit] = {
     for {
       articles <- fetchNitfBundle()

--- a/src/main/scala/com/gu/kindlegen/app/Settings.scala
+++ b/src/main/scala/com/gu/kindlegen/app/Settings.scala
@@ -74,12 +74,14 @@ object S3SettingsReader extends ValueReader[S3Settings] {
   override def read(config: Config, path: String): S3Settings = {
     val bucketName      = config.as[String](BucketName)
     val bucketDirectory = config.as[String](BucketDirectory).stripSuffix("/")
+    val publicDirectory = config.as[String](PublicDirectory).stripSuffix("/")
     val tmpDirOnDisk    = config.as[Option[Path]](TmpDirOnDisk)
-    S3Settings(bucketName, bucketDirectory, tmpDirOnDisk)
+    S3Settings(bucketName, bucketDirectory, publicDirectory, tmpDirOnDisk)
   }
 
   private final val BucketName = "bucket"
   private final val BucketDirectory = "prefix"
+  private final val PublicDirectory = "publicDirectory"
   private final val TmpDirOnDisk = "tmpDirOnDisk"
 }
 

--- a/src/test/scala/com/gu/io/TempFiles.scala
+++ b/src/test/scala/com/gu/io/TempFiles.scala
@@ -11,8 +11,8 @@ import org.scalatest.{BeforeAndAfterAll, Suite}
 trait TempFiles extends BeforeAndAfterAll { this: Suite =>
   import Files._
 
-  protected var createdTempPaths: ListSet[Path] = ListSet.empty
-  protected def trackTempFile(x: Path): Path = { createdTempPaths += x; x }
+  var createdTempPaths: ListSet[Path] = ListSet.empty
+  def trackTempFile(x: Path): Path = { createdTempPaths += x; x }
 
   protected def newTempDir: Path = trackTempFile(createTempDirectory(null))
   protected def newTempFile: Path = trackTempFile(createTempFile(null, null))


### PR DESCRIPTION
We configure Amazon's KPP with a stable URL that should point to each day's data.
This commit enables us to have a stable path within the S3 bucket via a redirect.

The redirect is recreated every time the Lambda is run to point to the generated
files. For example, the following link:
http://my-bucket.s3-website-eu-west-1.amazonaws.com/CODE/CurrentIssue/hierarchical-title-manifest.xml
will point to:
http://my-bucket.s3-website-eu-west-1.amazonaws.com/CODE/2018-07-02/hierarchical-title-manifest.xml