### PR TITLE
Give generated weather articles the same pubDate as other articles

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -67,7 +67,7 @@ weather {
 
     Sunday {
       id = "theobserver/weather"
-      title = "Observer Programmic Weather"
+      title = "Observer Weather"
       link = "https://www.theguardian.com/theguardian/mainsection/weather2"
     }
   }

--- a/src/main/scala/com/gu/kindlegen/Manifests.scala
+++ b/src/main/scala/com/gu/kindlegen/Manifests.scala
@@ -6,13 +6,13 @@ import com.gu.io.Link
 
 
 object ArticlesManifest {
-  def apply(section: BookSection, buildInstant: Instant = Instant.now): RssManifest = {
+  def apply(book: BookSection, buildInstant: Instant = Instant.now): RssManifest = {
     RssManifest(
-      title = section.title,
-      link = section.link,
+      title = book.title,
+      link = book.link,
       buildInstant = buildInstant,
-      publicationDate = section.publicationDate,
-      items = section.articles.map(article => RssItem(article.title, article.link))
+      publicationDate = book.publicationDate,
+      items = book.articles.map(article => RssItem(article.title, article.link))
     )
   }
 }

--- a/src/main/scala/com/gu/kindlegen/app/Lambda.scala
+++ b/src/main/scala/com/gu/kindlegen/app/Lambda.scala
@@ -1,13 +1,13 @@
 package com.gu.kindlegen.app
 
 import java.nio.file.{Files, Path}
-import java.time.{Instant, LocalDate, LocalTime, ZoneId}
+import java.time._
 import java.time.ZoneOffset.UTC
 import java.time.temporal.ChronoUnit.HOURS
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.duration.{Duration, _}
 import scala.util.Failure
 
 import com.amazonaws.services.lambda.runtime.Context
@@ -122,7 +122,7 @@ class Lambda(settings: Settings, date: LocalDate) extends Logging {
 
     val deletePublicDir = publisher
       .undirect(settings.s3.publicDirectory)
-      .andThen { case Failure(error) => logger.warn("Deleting the public directory failed!", error) }
+      .andThen { case Failure(error) => logger.error("Deleting the public directory failed!", error) }
 
     val generateFiles = deletePublicDir
       .flatMap(_ => doRun(publisher))
@@ -171,7 +171,8 @@ class Lambda(settings: Settings, date: LocalDate) extends Logging {
                              (implicit ec: ExecutionContext): ArticlesProvider = {
     val client = AccuWeatherClient(settings.accuWeather, downloader)
     val section = settings.weather.sections(date.getDayOfWeek)
-    new DailyWeatherForecastProvider(client, section, settings.weather)
+    val editionDate = date.atStartOfDay.atOffset(ZoneOffset.UTC)  // same offset as CAPI articles
+    new DailyWeatherForecastProvider(client, section, editionDate, settings.weather)
   }
 
   private def s3Publisher(settings: Settings)(implicit ec: ExecutionContext): S3Publisher = {

--- a/src/main/scala/com/gu/kindlegen/weather/DailyWeatherForecastProvider.scala
+++ b/src/main/scala/com/gu/kindlegen/weather/DailyWeatherForecastProvider.scala
@@ -20,6 +20,7 @@ object DailyWeatherForecastProvider {
 
 class DailyWeatherForecastProvider(client: WeatherClient,
                                    section: Section,
+                                   editionDate: OffsetDateTime,
                                    settings: WeatherSettings)(implicit ec: ExecutionContext)
     extends ArticlesProvider with Logging {
 
@@ -49,7 +50,7 @@ class DailyWeatherForecastProvider(client: WeatherClient,
           section = section,
           pageNumber = articleSettings.pageNumber,
           link = link,
-          pubDate = OffsetDateTime.now,
+          pubDate = editionDate,
           byline = articleSettings.byline,
           articleAbstract = articleSettings.articleAbstract.getOrElse(""),
           bodyBlocks = Seq(content.mkString),

--- a/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/KindleGeneratorSpec.scala
@@ -2,6 +2,7 @@ package com.gu.kindlegen
 
 import java.nio.file.{Files, Path}
 import java.time.LocalDate
+import java.time.ZoneOffset.UTC
 
 import scala.concurrent.Await
 import scala.xml.XML
@@ -41,7 +42,8 @@ class KindleGeneratorSpec extends FunSpec with TempFiles {
     val weatherClient = AccuWeatherClient(settings.accuWeather.apiKey, settings.accuWeather.baseUrl, downloader)
     val publisher = FilePublisher(fileSettings.outputDir.resolve(editionDate.toString))
     val capiProvider = GuardianArticlesProvider(settings.contentApi, settings.articles, downloader, editionDate)
-    val weatherProvider = new DailyWeatherForecastProvider(weatherClient, settings.weather.sections(editionDate.getDayOfWeek), settings.weather)
+    val weatherProvider = new DailyWeatherForecastProvider(
+      weatherClient, settings.weather.sections(editionDate.getDayOfWeek), editionDate.atStartOfDay.atOffset(UTC), settings.weather)
     val provider = new CompositeArticlesProvider(capiProvider, weatherProvider)
     val binder = MainSectionsBookBinder(settings.books.mainSections)
     val generator = new KindleGenerator(provider, binder, publisher, downloader, settings.articles.downloadTimeout, settings.publishing)

--- a/src/test/scala/com/gu/kindlegen/weather/DailyWeatherForecastProviderSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/weather/DailyWeatherForecastProviderSpec.scala
@@ -1,5 +1,7 @@
 package com.gu.kindlegen.weather
 
+import java.time.OffsetDateTime
+
 import scala.concurrent.Future
 import scala.xml.{Elem, XML}
 
@@ -51,7 +53,7 @@ class DailyWeatherForecastProviderSpec extends FunSpec {
 
   private def provider(settings: WeatherSettings) = {
     implicit val ec = SideEffectsExecutionContext  // discard errors reported by Future#andThen and FutureUtils.successfulSequence
-    new DailyWeatherForecastProvider(client, section, settings = settings)
+    new DailyWeatherForecastProvider(client, section, OffsetDateTime.now, settings)
   }
 
   it("creates an article with a forecast for each city") {


### PR DESCRIPTION
It appears that having different publication dates causes an issue when
Amazon KPP generates an edition. In particular, KPP generates an edition
that only contains the sections with the latest publication date.

This isn't a problem in the live code, but it becomes an issue when we
try to preview older editions. It would also become a problem if the
edition was being generated at 11:59 PM on the day before publication.