### PR TITLE
Pre-run the Lambda to detect issues early

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -85,14 +85,18 @@ Resources:
                 ${CustomConfig}
               }
       Events:
-        DailyGMT:
+        DailyGMTRun:
           Type: Schedule
           Properties:
             Schedule: cron(10 1 * * ? *)  # Run at 01:10 AM GMT (UTC+0) every day
-        DailyBST:
+        DailyBSTRunGMTPrerun:
           Type: Schedule
           Properties:
-            Schedule: cron(10 0 * * ? *)  # Run at 01:10 AM BST (UTC+1) every day
+            Schedule: cron(10 0 * * ? *)  # Run at 12:10 AM GMT (UTC+0) / 01:10 AM BST (UTC+1) every day
+        DailyBSTPrerun:
+          Type: Schedule
+          Properties:
+            Schedule: cron(10 23 * * ? *)  # Run at 12:10 AM BST (UTC+1) every day
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
@@ -186,7 +190,7 @@ Resources:
       Statistic:          Sum
       ComparisonOperator: LessThanThreshold
       Threshold:          1
-      Period: 86700  # 1 day and 5 minutes
+      Period: 86400  # 1 day
       EvaluationPeriods: 1
       TreatMissingData: breaching
       AlarmActions:

--- a/cfn.yaml
+++ b/cfn.yaml
@@ -111,6 +111,26 @@ Resources:
               - s3:PutBucketWebsite
             Resource: !Sub "arn:aws:s3:::${OutputBucket}"
 
+  LambdaOutputBucket:
+    Type: "AWS::S3::Bucket"
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Ref OutputBucket
+      AccessControl: PublicRead
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 366
+            Status: Enabled
+      WebsiteConfiguration:
+        IndexDocument: index.html  # not actually used
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
   LambdaLogErrors:
     Type: "AWS::Logs::MetricFilter"
     Properties:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -46,6 +46,7 @@ publishing {
 run {
   localHour = "01:00"  // between 01:00 and 01:59 local time
   zone = "Europe/London"
+  outputDirDateFormat = "yyyy-MM-dd"
 }
 
 s3 {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -44,9 +44,9 @@ publishing {
 }
 
 run {
-  localHour = "01:00"  // between 01:00 and 01:59 local time
+  localHours = ["00:00", "01:00"]  // between 00:00 and 01:59
   zone = "Europe/London"
-  outputDirDateFormat = "yyyy-MM-dd"
+  outputDirDateFormat = "yyyy-MM-dd/HH00"
 }
 
 s3 {

--- a/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
@@ -126,8 +126,9 @@ object SettingsSpec {
     ).toConfigObj }.asJava
   )
 
+  private val localHours = Seq("06:00", "07:00")
   private val runValues = Map(
-    "localHour" -> "06:00",
+    "localHours" -> localHours.asJava,
     "zone" -> "Antarctica/South_Pole",
     "outputDirDateFormat" -> "yyyy-MM-ddTHH-mm",
   )
@@ -246,7 +247,7 @@ object SettingsSpec {
   }
 
   private def validateValues(runSettings: RunSettings): Assertion = {
-    runSettings.localHour.toString shouldBe runValues("localHour")
+    runSettings.localHours.map(_.toString) should contain theSameElementsAs localHours
     runSettings.zone.toString shouldBe runValues("zone")
     runSettings.outputDirDateFormat shouldBe runValues("outputDirDateFormat")
   }

--- a/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/app/SettingsSpec.scala
@@ -128,7 +128,8 @@ object SettingsSpec {
 
   private val runValues = Map(
     "localHour" -> "06:00",
-    "zone" -> "Antarctica/South_Pole"
+    "zone" -> "Antarctica/South_Pole",
+    "outputDirDateFormat" -> "yyyy-MM-ddTHH-mm",
   )
 
   private val s3Values = Map(
@@ -247,6 +248,7 @@ object SettingsSpec {
   private def validateValues(runSettings: RunSettings): Assertion = {
     runSettings.localHour.toString shouldBe runValues("localHour")
     runSettings.zone.toString shouldBe runValues("zone")
+    runSettings.outputDirDateFormat shouldBe runValues("outputDirDateFormat")
   }
 
   private def validateValues(s3Settings: S3Settings)(implicit tmpHelper: TempFiles): Assertion = {


### PR DESCRIPTION
I was asked to configure a "test run" for the lambda around midnight so that we can detect issues earlier than the final run around 1 AM.