### PR TITLE
Fix formatting issues

### DIFF
--- a/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/ArticleFactory.scala
@@ -80,7 +80,10 @@ class ArticleFactory(settings: GuardianProviderSettings, imageFactory: ImageFact
       case element if element.`type` == Text => element.textTypeData.flatMap(_.html)
       case element if element.`type` == Tweet => element.tweetTypeData.flatMap(_.html)
     }
-    htmlBlocks.flatten
+    // sadly, starting from the second block, the first paragraph of each block is not indented
+    // to work around this, we combine all blocks into one.
+    val combinedBlocks = htmlBlocks.flatten.mkString("\n")
+    Seq(combinedBlocks)
   }
 
   private def sectionFrom(tag: Tag): Section =

--- a/src/main/scala/com/gu/kpp/nitf/XhtmlToNitfTransformer.scala
+++ b/src/main/scala/com/gu/kpp/nitf/XhtmlToNitfTransformer.scala
@@ -26,6 +26,7 @@ class XhtmlToNitfTransformer(config: HtmlToNitfConfig) {
     convertMisplacedLists,
     removeUnsupportedAttributes,
     removeTagsMissingRequiredAttributes,
+    replaceBreaksInAbstract,
     wrapTextIntoBlockContent,
     wrapSpecialElements,
     unwrapTopLevelTags
@@ -107,6 +108,13 @@ class XhtmlToNitfTransformer(config: HtmlToNitfConfig) {
     rewriteRule("Remove tags missing required attributes") {
       case e: Elem if tags.contains(e.label) && e.attributes.isEmpty =>
         e.unwrapChildren(_ => true)
+    }
+  }
+
+  private val replaceBreaksInAbstract = {
+    rewriteRule("Replace <br/> in <abstract> with a dash") {
+      case e: Elem if e.label == "abstract" =>
+        e.replaceDescendantsOrSelf { case n if n.label == "br" => Text(" – ") }
     }
   }
 

--- a/src/main/scala/com/gu/xml/package.scala
+++ b/src/main/scala/com/gu/xml/package.scala
@@ -209,14 +209,15 @@ object `package` {
       sb.append(NodeSeq.fromSeq(trimProper(n)).toString)
     }
 
-    // copied from https://github.com/scala/scala-xml/pull/113/files
-    // TODO use Utility.trimProper when scala-xml v1.1.1 is released
+    // adapted from https://github.com/scala/scala-xml/pull/113/files
     private def trimProper(x: Node): Seq[Node] = x match {
       case Elem(pre, lab, md, scp, child@_*) =>
         val children = combineAdjacentTextNodes(child) flatMap trimProper
         Elem(pre, lab, md, scp, children.isEmpty, children: _*)
+      case Text(spaces) if spaces.forall(_.isWhitespace) =>
+          Nil
       case Text(s) =>
-        new TextBuffer().append(s).toText
+        Text(leadingOrTrailingSpaces.replaceAllIn(s, " "))  // keep a leading or trailing space if one already exists
       case _ =>
         x
     }
@@ -227,5 +228,7 @@ object `package` {
         case (n, acc) => n +: acc
       }
     }
+
+    private val leadingOrTrailingSpaces = raw"\A\s+|\s+\z".r
   }
 }

--- a/src/main/scala/com/gu/xml/package.scala
+++ b/src/main/scala/com/gu/xml/package.scala
@@ -97,6 +97,13 @@ object `package` {
       }
     }
 
+    def replaceDescendantsOrSelf(replacement: PartialFunction[Node, Node]): Seq[Node] = node match {
+      case n if replacement.isDefinedAt(n) => replacement(n)
+      case e: Elem if e.descendant.exists(replacement.isDefinedAt) =>
+        e.copy(child = e.child.flatMap(_.replaceDescendantsOrSelf(replacement)))
+      case n => n
+    }
+
     /** Creates an element that matches this node, unless this node is a [[scala.xml.SpecialNode]]. */
     def toElem: Option[Elem] = node match {
       case e: Elem => Some(e)

--- a/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
+++ b/src/test/scala/com/gu/kindlegen/ArticleNITFSpec.scala
@@ -73,12 +73,12 @@ class ArticleNITFSpec extends FunSpec {
     it("removes links and preserves whitespaces") {
       val article = simpleArticle.copy(bodyBlocks = Seq(
         """<p>This is <a href="http://example.com">an example</a>""" +
-        """ that contains <a href="https://elsewhere.net">some links</a>.</p>"""
+        """ that contains <a href="https://elsewhere.net">some<em> links</em></a>.</p>"""
       ))
 
       val nitf = ArticleNITF(article).nitf
       val paragraph = nitf \\ "body.content" \\ "p"
-      paragraph.mkString shouldBe "<p>This is an example that contains some links.</p>"
+      paragraph.mkString shouldBe "<p>This is an example that contains some<em> links</em>.</p>"
     }
   }
 }

--- a/src/test/scala/com/gu/xml/XmlSpec.scala
+++ b/src/test/scala/com/gu/xml/XmlSpec.scala
@@ -15,7 +15,7 @@ class XmlSpec extends FunSpec {
 
     it("maintains spaces inside contiguous text nodes") {
       val xml = <a/>.copy(child = Seq("   ", "Some ", "text", " with", " spaces ", "...", "   ").map(Text.apply))
-      TrimmingPrinter.format(xml) shouldBe "<a>Some text with spaces ...</a>"
+      TrimmingPrinter.format(xml) shouldBe "<a> Some text with spaces ... </a>"
     }
   }
 }


### PR DESCRIPTION
1. **Par styling within 'blocks'**
    Example: Any article
    Paragraph style on the device is first par no indent, subsequent pars indented.
    However we're wrapping pars in blocks eg:
    ```xml
    <block>
    <p>This is the first par</p>
    <p>This is the second par</p>
    <p>This is the third par</p>
    </block>
    <block>
    <p>This is the fourth par</p>
    <p>This is the fifth par</p>
    <p>This is the six par</p>
    </block>
    ```
    This causes no indent on the fourth par which makes reading harder on the kindle.
    David Blishen said:
    > I was wondering what the purpose of blocks are in the nitf? If they're just to mirror our blocks in CAPI, then perhaps we shouldn't include them, since the formatting is changed as a result.

    > Can we just try concatenating all blocks? I think that would be consistent with the existing version, and actually would help us see other issues, as this one alone makes particularly the Observer, quite difficult to check carefully.

2. **Text runs on in <abstract> tag**
    Example: `2018-07-01/90_games_2018_jun_30_jurassic-world-evolution-review-frontier-developments.nitf.xml`
    ![kindle-abstract-linebreak](https://user-images.githubusercontent.com/330633/42447669-9f48ab8c-8372-11e8-8202-6de43e1b9b31.jpg)
    Looking in the markup, we can see a line break (`<br/>`) between "Developments" and "Dead", since there is a break. But the run on was present in multiple devices.
    ```xml
    <body.head>
    <hedline>
    <hl1>Jurassic World Evolution review – thrills at risk of extinction</hl1></hedline>
    <byline>Simon Parkin</byline>
    <abstract>
      <p><em>(PS4, Xbox 1, PC) Frontier Developments</em><br/>Dead dinosaurs are only half the problem in an exhausting Jurassic Park simulation that puts business first</p>
    </abstract>
    </body.head>
    ```
    Hosam Aly said:
    > I'm inclined to think that Kindle doesn't support a line break in an abstract. I could replace it with something, e.g. a colon. What do you think?
    David Blishen said:
    > Yeah - let's try " - "
    Mateusz Karpow said:
    > [It] should be " – " (more in line with a style guide, but not sure Amazon fonts support en dash)

3. **Issues with spacing around style runs**
    Strong and Em tags can remove spacing.
    This was masked hugely as the Kindle style appears to introduce some space when a bold or italic tag opens and closes.
    **Examples:**
    * `2018-07-01/138_film_2018_jul_01_radar-debra-granik-winters-bone-kate-mckinnon-mierle-ukeles-fast-food-rbg.nitf.xml`
        • Notice the space before "in Cambridge"
        **NITF**: `Debra Granik was born in 1963</strong><strong>in Cambridge`
        **CAPI**: `Debra Granik was born in 1963</strong><strong> in Cambridge`
    * `2018-07-01/152_media_2018_jul_01_is-today-programme-losing-its-grip.nitf.xml`
        • Notice the space before and after "Today"
        **NITF**: `to appear on it, the<em>Today</em>programme has been a fixture`
        **CAPI**: `to appear on it, the <em>Today </em>programme has been a fixture`