### PR TITLE
Change the HTTP redirect code in S3 to 302 Moved Temporarily

### DIFF
--- a/src/main/scala/com/gu/io/aws/S3Publisher.scala
+++ b/src/main/scala/com/gu/io/aws/S3Publisher.scala
@@ -92,7 +92,7 @@ case class S3Publisher(s3: AmazonS3, settings: S3PublisherSettings)
     val toDir = normalizeDir(toDirectory)
     new RoutingRule()
       .withCondition(new RoutingRuleCondition().withKeyPrefixEquals(fromDir))
-      .withRedirect(new RedirectRule().withReplaceKeyPrefixWith(toDir))
+      .withRedirect(new RedirectRule().withReplaceKeyPrefixWith(toDir).withHttpRedirectCode("302"))
   }
 
   private def normalizeDir(dirName: String): String = {


### PR DESCRIPTION
The redirect changes every time the Lambda runs.
It used to return HTTP 301 Moved Permanently, which is semantically
incorrect and could lead some clients to cache the redirect.

HTTP clients should recognise the 302 and never cache the redirect.