### PR TITLE
Filter out potential duplicates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description:= "Converting content to NITF format"
 
 version := "1.0"
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.7"
 
 scalacOptions ++= Seq(
   "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.7

--- a/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
@@ -50,12 +50,7 @@ class GuardianArticlesProvider(capiClient: ContentApiClient,
   }
 
   def articles(results: Seq[Content]): Seq[Article] = {
-    val (_, articles) = results.foldLeft[(Set[String], Seq[Article])]((Set.empty, Nil)) { case ((ids, articles), article) =>
-      if (!ids(article.id))
-        ids -> (articles ++ toArticle(article))
-      else
-        (ids + article.id) -> articles
-    }
+    val articles = results.groupBy(_.id).flatMap(_._2.headOption).toSeq.flatMap(toArticle)
     logger.info(s"Processed ${articles.length} articles.")
     articles
   }

--- a/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
+++ b/src/main/scala/com/gu/kindlegen/capi/GuardianArticlesProvider.scala
@@ -50,7 +50,12 @@ class GuardianArticlesProvider(capiClient: ContentApiClient,
   }
 
   def articles(results: Seq[Content]): Seq[Article] = {
-    val articles = results.flatMap(toArticle)
+    val (_, articles) = results.foldLeft[(Set[String], Seq[Article])]((Set.empty, Nil)) { case ((ids, articles), article) =>
+      if (!ids(article.id))
+        ids -> (articles ++ toArticle(article))
+      else
+        (ids + article.id) -> articles
+    }
     logger.info(s"Processed ${articles.length} articles.")
     articles
   }


### PR DESCRIPTION
A user complained about articles sometimes appearing twice in the same edition:

> Firstly may I refer you to my email of the 18th November. It's happened again!  The article by Arwa Mahdawin("*Only a fool would have bought into bit coin...*") is in the Kindle *twice*, on the same day (today, 26/11), I suggest strongly that you take action against the subeditor culprit responsible for this sloppy output. I do pay for this edition although I'm aware that I could read many of the articles for free, on line.

This changes takes them out at the source.